### PR TITLE
Refactor the integral data types, and some casting, for BsMemoryAllocator.h

### DIFF
--- a/Source/Foundation/bsfCore/Material/BsMaterial.cpp
+++ b/Source/Foundation/bsfCore/Material/BsMaterial.cpp
@@ -611,7 +611,7 @@ namespace bs
 		UINT32 bufferSize = 0;
 
 		MemorySerializer serializer;
-		UINT8* buffer = serializer.encode(this, bufferSize, (void*(*)(UINT32))&bs_alloc);
+		UINT8* buffer = serializer.encode(this, bufferSize, (void*(*)(size_t))&bs_alloc);
 
 		SPtr<Material> cloneObj = std::static_pointer_cast<Material>(serializer.decode(buffer, bufferSize));
 		bs_free(buffer);

--- a/Source/Foundation/bsfCore/Scene/BsSceneObject.cpp
+++ b/Source/Foundation/bsfCore/Scene/BsSceneObject.cpp
@@ -45,7 +45,7 @@ namespace bs
 	{
 		SPtr<SceneObject> sceneObjectPtr = SPtr<SceneObject>(new (bs_alloc<SceneObject>()) SceneObject(name, flags),
 			&bs_delete<SceneObject>, StdAlloc<SceneObject>());
-		
+
 		HSceneObject sceneObject = GameObjectManager::instance().registerObject(sceneObjectPtr);
 		sceneObject->mThisHandle = sceneObject;
 
@@ -735,7 +735,7 @@ namespace bs
 		UINT32 bufferSize = 0;
 
 		MemorySerializer serializer;
-		UINT8* buffer = serializer.encode(this, bufferSize, (void*(*)(UINT32))&bs_alloc);
+		UINT8* buffer = serializer.encode(this, bufferSize, (void*(*)(size_t))&bs_alloc);
 
 		GameObjectManager::instance().setDeserializationMode(GODM_UseNewIds | GODM_RestoreExternal);
 		SPtr<SceneObject> cloneObj = std::static_pointer_cast<SceneObject>(serializer.decode(buffer, bufferSize));

--- a/Source/Foundation/bsfUtility/Allocators/BsStackAlloc.h
+++ b/Source/Foundation/bsfUtility/Allocators/BsStackAlloc.h
@@ -4,7 +4,10 @@
 
 #include <stack>
 #include <assert.h>
+
+#include "Prerequisites/BsTypes.h"
 #include "Prerequisites/BsStdHeaders.h"
+
 #include "Threading/BsThreadDefines.h"
 
 namespace bs


### PR DESCRIPTION
Mostly it's removing casts that I don't see the benefit of, and normalizing the integer data types used as function parameters. E.g. using size_t when counting "number objects" and such.