### PR TITLE
Remove duplicated mFrustumData clear in `void DrawHelper::clear()`

### DIFF
--- a/Source/Foundation/bsfEngine/Utility/BsDrawHelper.cpp
+++ b/Source/Foundation/bsfEngine/Utility/BsDrawHelper.cpp
@@ -314,7 +314,6 @@ namespace bs
 		mLineListData.clear();
 		mRect3Data.clear();
 		mFrustumData.clear();
-		mFrustumData.clear();
 		mDiscData.clear();
 		mWireDiscData.clear();
 		mArcData.clear();


### PR DESCRIPTION
I've looked `DrawHelper` over, and it does not look like any of the member `Vector` instances was skipped over, so `mFrustumData.clear()` was just redundant. 