### PR TITLE
Fix an error in Win32GLSupport::selectPixelFormat

### DIFF
--- a/Source/Plugins/bsfGLRenderAPI/Win32/BsWin32GLSupport.cpp
+++ b/Source/Plugins/bsfGLRenderAPI/Win32/BsWin32GLSupport.cpp
@@ -308,7 +308,10 @@ namespace bs { namespace ct
 			attribList.push_back(WGL_SAMPLES_ARB); attribList.push_back(multisample);
 
 			if (useHwGamma && checkExtension("WGL_EXT_framebuffer_sRGB"))
-				attribList.push_back(WGL_FRAMEBUFFER_SRGB_CAPABLE_EXT); attribList.push_back(GL_TRUE);
+			{
+				attribList.push_back(WGL_FRAMEBUFFER_SRGB_CAPABLE_EXT);
+				attribList.push_back(GL_TRUE);
+			}
 
 			attribList.push_back(0); // Terminator
 


### PR DESCRIPTION
Just a missing `{` `}` that was causing spurious `attribList.push_back(GL_TRUE);` when `WGL_EXT_framebuffer_sRGB` was not present.