### PR TITLE
Fix compilation issues with ICU>=61

### DIFF
--- a/Source/Foundation/bsfUtility/Private/Linux/BsLinuxPlatformUtility.cpp
+++ b/Source/Foundation/bsfUtility/Private/Linux/BsLinuxPlatformUtility.cpp
@@ -126,6 +126,7 @@ namespace bs
 
 	String PlatformUtility::convertCaseUTF8(const String& input, bool toUpper)
 	{
+		U_NAMESPACE_USE;
 		UnicodeString uniStr = UnicodeString::fromUTF8(StringPiece(&input[0], input.size()));
 
 		if(toUpper)


### PR DESCRIPTION
"Since ICU 61, call sites need to qualify ICU types explicitly, for example icu::UnicodeString, or do using icu::UnicodeString; where appropriate. If your code relies on the "using namespace icu;" that used to be in unicode/uversion.h, then you need to update your code."

I've fixed it the simplest possible way.