### PR TITLE
Make EnumClassHash operator() constexpr

### DIFF
--- a/Source/Foundation/bsfUtility/Prerequisites/BsStdHeaders.h
+++ b/Source/Foundation/bsfUtility/Prerequisites/BsStdHeaders.h
@@ -72,9 +72,11 @@ extern "C" {
 
 #if BS_PLATFORM == BS_PLATFORM_OSX
 extern "C" {
+
 #   include <unistd.h>
 #   include <sys/param.h>
 #   include <CoreFoundation/CoreFoundation.h>
+
 }
 #endif
 
@@ -93,7 +95,7 @@ namespace bs
 	struct EnumClassHash
 	{
 		template <typename T>
-		std::size_t operator()(T t) const
+		constexpr std::size_t operator()(T t) const
 		{
 			return static_cast<std::size_t>(t);
 		}


### PR DESCRIPTION
It's just a static_cast, no reason it shouldn't be constexpr.

By the way, I notice that there's no typedef for std::forward_list. It has slightly better performance than std::list for certain operations (and worse for others, of course).