### PR TITLE
Bugfix: improperly locked mutexes.

### DIFF
--- a/Source/Foundation/bsfCore/Managers/BsGpuProgramManager.cpp
+++ b/Source/Foundation/bsfCore/Managers/BsGpuProgramManager.cpp
@@ -3,7 +3,7 @@
 #include "Managers/BsGpuProgramManager.h"
 #include "RenderAPI/BsRenderAPI.h"
 
-namespace bs 
+namespace bs
 {
 	SPtr<GpuProgram> GpuProgramManager::create(const GPU_PROGRAM_DESC& desc)
 	{
@@ -96,14 +96,14 @@ namespace bs
 
 	void GpuProgramManager::addFactory(const String& language, GpuProgramFactory* factory)
 	{
-		Lock(mMutex);
+		Lock lock_it(mMutex);
 
 		mFactories[language] = factory;
 	}
 
 	void GpuProgramManager::removeFactory(const String& language)
 	{
-		Lock(mMutex);
+		Lock lock_it(mMutex);
 
 		auto iter = mFactories.find(language);
 		if (iter != mFactories.end())
@@ -121,7 +121,7 @@ namespace bs
 
 	bool GpuProgramManager::isLanguageSupported(const String& lang)
 	{
-		Lock(mMutex);
+		Lock lock_it(mMutex);
 
 		auto iter = mFactories.find(lang);
 		return iter != mFactories.end();

--- a/Source/Foundation/bsfCore/Resources/BsResourceHandle.cpp
+++ b/Source/Foundation/bsfCore/Resources/BsResourceHandle.cpp
@@ -17,13 +17,13 @@ namespace bs
 		mData = nullptr;
 	}
 
-	ResourceHandleBase::~ResourceHandleBase() 
-	{ 
+	ResourceHandleBase::~ResourceHandleBase()
+	{
 
 	}
 
-	bool ResourceHandleBase::isLoaded(bool checkDependencies) const 
-	{ 
+	bool ResourceHandleBase::isLoaded(bool checkDependencies) const
+	{
 		bool isLoaded = (mData != nullptr && mData->mIsCreated && mData->mPtr != nullptr);
 
 		if (checkDependencies && isLoaded)
@@ -84,14 +84,14 @@ namespace bs
 		if(mData->mPtr)
 		{
 			mData->mUUID = uuid;
-		
+
 			if(!mData->mIsCreated)
 			{
 				Lock lock(mResourceCreatedMutex);
 				{
-					mData->mIsCreated = true; 
+					mData->mIsCreated = true;
 				}
-				
+
 				mResourceCreatedCondition.notify_all();
 			}
 		}
@@ -101,7 +101,7 @@ namespace bs
 	{
 		mData->mPtr = nullptr;
 
-		Lock(mResourceCreatedMutex);
+		Lock lock_it(mResourceCreatedMutex);
 		mData->mIsCreated = false;
 	}
 


### PR DESCRIPTION
`Lock(mMutex);` is actually defining a local `Lock` variable named `mMutex` and not locking the mMutex

Since `-Wno-unused-variable` was added to gcc/clang options they were not reporting this.

Thanks go to gcc's 8.1 new `-Wparentheses` warning