### PR TITLE
Fix: BsDynLibManager "unload"

### DIFF
--- a/Source/Foundation/bsfUtility/Prerequisites/BsStdHeaders.h
+++ b/Source/Foundation/bsfUtility/Prerequisites/BsStdHeaders.h
@@ -223,12 +223,12 @@ namespace bs
 		constexpr T& operator*() const { return *mPtr; }
 		constexpr T* operator->() const { return mPtr; }
 		constexpr T* get() const { return mPtr; }
-		constexpr bool operator< (const NativePtr& rhs) const { return mPtr <  rhs.mPtr; }
-		constexpr bool operator> (const NativePtr& rhs) const { return mPtr >  rhs.mPtr; }
-		constexpr bool operator<=(const NativePtr& rhs) const { return mPtr <= rhs.mPtr; }
-		constexpr bool operator>=(const NativePtr& rhs) const { return mPtr >= rhs.mPtr; }
-		constexpr bool operator==(const NativePtr& rhs) const { return mPtr == rhs.mPtr; }
-		constexpr bool operator!=(const NativePtr& rhs) const { return mPtr != rhs.mPtr; }
+		bool operator< (const NativePtr& rhs) const { return mPtr <  rhs.mPtr; }
+		bool operator> (const NativePtr& rhs) const { return mPtr >  rhs.mPtr; }
+		bool operator<=(const NativePtr& rhs) const { return mPtr <= rhs.mPtr; }
+		bool operator>=(const NativePtr& rhs) const { return mPtr >= rhs.mPtr; }
+		bool operator==(const NativePtr& rhs) const { return mPtr == rhs.mPtr; }
+		bool operator!=(const NativePtr& rhs) const { return mPtr != rhs.mPtr; }
 
 	private:
 		T* mPtr = nullptr;

--- a/Source/Foundation/bsfUtility/Utility/BsDynLibManager.cpp
+++ b/Source/Foundation/bsfUtility/Utility/BsDynLibManager.cpp
@@ -14,7 +14,10 @@ namespace bs
 	{
 		return lhs < rhs->getName();
 	}
-
+	template<>
+	bool NPtr<DynLib>::operator<(const NPtr<DynLib>& rhs) const {
+		return mPtr->getName() < rhs->getName();
+	}
 	DynLib* DynLibManager::load(String filename)
 	{
 		// Add the extension (.dll, .so, ...) if necessary.


### PR DESCRIPTION
Since default comparator compares pointers and the `mLoadedLibraries`
needs to compare by `getName()` strings, using template specialization
should solve the problem.
In my limited testing this seems to work correctly, but @XMatrixXiang please check if this solves the issue you were having.
Fixes #111