### PR TITLE
Prevent odr violation

### DIFF
--- a/Source/Plugins/bsfD3D11RenderAPI/BsD3D11Plugin.cpp
+++ b/Source/Plugins/bsfD3D11RenderAPI/BsD3D11Plugin.cpp
@@ -5,8 +5,8 @@
 
 namespace bs
 {
-	extern "C" BS_PLUGIN_EXPORT const char* getPluginName()
-	{
-		return ct::SystemName;
-	}
+    extern "C" BS_PLUGIN_EXPORT const char* getPluginName()
+    {
+        return ct::D3D11RenderAPIFactory::SystemName;
+    }
 }

--- a/Source/Plugins/bsfD3D11RenderAPI/BsD3D11RenderAPIFactory.cpp
+++ b/Source/Plugins/bsfD3D11RenderAPI/BsD3D11RenderAPIFactory.cpp
@@ -5,12 +5,12 @@
 
 namespace bs { namespace ct
 {
-	const char* SystemName = "BansheeD3D11RenderSystem";
+    const char* D3D11RenderAPIFactory::SystemName = "BansheeD3D11RenderSystem";
 
-	void D3D11RenderAPIFactory::create()
-	{
-		RenderAPI::startUp<D3D11RenderAPI>();
-	}
+    void D3D11RenderAPIFactory::create()
+    {
+        RenderAPI::startUp<D3D11RenderAPI>();
+    }
 
-	D3D11RenderAPIFactory::InitOnStart D3D11RenderAPIFactory::initOnStart;
+    D3D11RenderAPIFactory::InitOnStart D3D11RenderAPIFactory::initOnStart;
 }}

--- a/Source/Plugins/bsfD3D11RenderAPI/BsD3D11RenderAPIFactory.cpp
+++ b/Source/Plugins/bsfD3D11RenderAPI/BsD3D11RenderAPIFactory.cpp
@@ -5,12 +5,12 @@
 
 namespace bs { namespace ct
 {
-    const char* D3D11RenderAPIFactory::SystemName = "BansheeD3D11RenderSystem";
+	const char* D3D11RenderAPIFactory::SystemName = "BansheeD3D11RenderSystem";
 
-    void D3D11RenderAPIFactory::create()
-    {
-        RenderAPI::startUp<D3D11RenderAPI>();
-    }
+	void D3D11RenderAPIFactory::create()
+	{
+		RenderAPI::startUp<D3D11RenderAPI>();
+	}
 
-    D3D11RenderAPIFactory::InitOnStart D3D11RenderAPIFactory::initOnStart;
+	D3D11RenderAPIFactory::InitOnStart D3D11RenderAPIFactory::initOnStart;
 }}

--- a/Source/Plugins/bsfD3D11RenderAPI/BsD3D11RenderAPIFactory.h
+++ b/Source/Plugins/bsfD3D11RenderAPI/BsD3D11RenderAPIFactory.h
@@ -14,8 +14,9 @@ namespace bs { namespace ct
 	/**	Handles creation of the DX11 render system. */
 	class D3D11RenderAPIFactory : public RenderAPIFactory
 	{
-		static const char* SystemName;
 	public:
+		static const char* SystemName;
+
 		/** @copydoc RenderAPIFactory::create */
 		void create() override;
 

--- a/Source/Plugins/bsfD3D11RenderAPI/BsD3D11RenderAPIFactory.h
+++ b/Source/Plugins/bsfD3D11RenderAPI/BsD3D11RenderAPIFactory.h
@@ -11,12 +11,10 @@ namespace bs { namespace ct
 	/** @addtogroup D3D11
 	 *  @{
 	 */
-
-	extern const char* SystemName;
-
 	/**	Handles creation of the DX11 render system. */
 	class D3D11RenderAPIFactory : public RenderAPIFactory
 	{
+		static const char* SystemName;
 	public:
 		/** @copydoc RenderAPIFactory::create */
 		void create() override;
@@ -30,8 +28,8 @@ namespace bs { namespace ct
 		class InitOnStart
 		{
 		public:
-			InitOnStart() 
-			{ 
+			InitOnStart()
+			{
 				static SPtr<RenderAPIFactory> newFactory;
 				if(newFactory == nullptr)
 				{

--- a/Source/Plugins/bsfGLRenderAPI/BsGLPlugin.cpp
+++ b/Source/Plugins/bsfGLRenderAPI/BsGLPlugin.cpp
@@ -5,8 +5,9 @@
 
 namespace bs
 {
+	const char* ct::GLRenderAPIFactory::SystemName = "BansheeGLRenderSystem";
 	extern "C" BS_PLUGIN_EXPORT const char* getPluginName()
 	{
-		return ct::SystemName;
+		return ct::GLRenderAPIFactory::SystemName;
 	}
 }

--- a/Source/Plugins/bsfGLRenderAPI/BsGLRenderAPIFactory.h
+++ b/Source/Plugins/bsfGLRenderAPI/BsGLRenderAPIFactory.h
@@ -12,13 +12,12 @@ namespace bs { namespace ct
 	/** @addtogroup GL
 	 *  @{
 	 */
-
-	static const char* SystemName = "BansheeGLRenderSystem";
-
 	/** Handles creation of the OpenGL render system. */
 	class GLRenderAPIFactory : public RenderAPIFactory
 	{
 	public:
+		static const char* SystemName;
+
 		/** @copydoc RenderAPIFactory::create */
 		void create() override;
 
@@ -30,8 +29,8 @@ namespace bs { namespace ct
 		class InitOnStart
 		{
 		public:
-			InitOnStart() 
-			{ 
+			InitOnStart()
+			{
 				static SPtr<RenderAPIFactory> newFactory;
 				if(newFactory == nullptr)
 				{

--- a/Source/Plugins/bsfRenderBeast/BsRenderBeastFactory.cpp
+++ b/Source/Plugins/bsfRenderBeast/BsRenderBeastFactory.cpp
@@ -6,7 +6,8 @@
 
 namespace bs
 {
-	const char* SystemName = "bsfRenderBeast";
+
+	const char* RenderBeastFactory::SystemName = "bsfRenderBeast";
 
 	SPtr<ct::Renderer> RenderBeastFactory::create()
 	{

--- a/Source/Plugins/bsfRenderBeast/BsRenderBeastFactory.h
+++ b/Source/Plugins/bsfRenderBeast/BsRenderBeastFactory.h
@@ -10,16 +10,15 @@ namespace bs
 	/** @addtogroup RenderBeast
 	 *  @{
 	 */
-
-	extern const char* SystemName;
-
 	/**
-	 * Renderer factory implementation that creates and initializes the default Banshee renderer. Used by the 
+	 * Renderer factory implementation that creates and initializes the default Banshee renderer. Used by the
 	 * RendererManager.
 	 */
 	class RenderBeastFactory : public RendererFactory
 	{
 	public:
+		static const char* SystemName;
+
 		/** @copydoc RendererFactory::create */
 		SPtr<ct::Renderer> create() override;
 

--- a/Source/Plugins/bsfRenderBeast/BsRenderBeastPlugin.cpp
+++ b/Source/Plugins/bsfRenderBeast/BsRenderBeastPlugin.cpp
@@ -9,7 +9,7 @@ namespace bs
 	/**	Returns a name of the plugin. */
 	extern "C" BS_PLUGIN_EXPORT const char* getPluginName()
 	{
-		return SystemName;
+		return RenderBeastFactory::SystemName;
 	}
 
 	/**	Entry point to the plugin. Called by the engine when the plugin is loaded. */

--- a/Source/Plugins/bsfSL/BsSLPlugin.cpp
+++ b/Source/Plugins/bsfSL/BsSLPlugin.cpp
@@ -6,11 +6,11 @@
 
 namespace bs
 {
-	const char* SystemName = "BansheeSL";
 
 	/**	Returns a name of the plugin. */
 	extern "C" BS_PLUGIN_EXPORT const char* getPluginName()
 	{
+		static const char* SystemName = "BansheeSL";
 		return SystemName;
 	}
 


### PR DESCRIPTION
This caused:
```
==7074==ERROR: AddressSanitizer: odr-violation (0x7fd163df7420):
  [1] size=8 'bs::SystemName' Games/bsf/Source/Plugins/bsfSL/BsSLPlugin.cpp:9:14
  [2] size=8 'bs::SystemName' Games/bsf/Source/Plugins/bsfRenderBeast/BsRenderBeastFactory.cpp:9:14
These globals were registered at these points:
  [1]:
    #0 0x4460e1 in __asan_register_globals.part.11 (Games/bsfExamples/bin/x64/Debug/LowLevelRendering+0x4460e1)
    #1 0x7fd14bd8754d in asan.module_ctor (Games/bsfExamples/bin/x64/Debug/libbsfSL.so+0x4a354d)

  [2]:
    #0 0x4460e1 in __asan_register_globals.part.11 (Games/bsfExamples/bin/x64/Debug/LowLevelRendering+0x4460e1)
    #1 0x7fd1638b0ccd in asan.module_ctor (Games/bsfExamples/bin/x64/Debug/libbsfRenderBeast.so+0x205ccd)
```