### PR TITLE
Remove many unused assignments + memset fix

### DIFF
--- a/Source/Foundation/bsfCore/Private/RTTI/BsAnimationClipRTTI.h
+++ b/Source/Foundation/bsfCore/Private/RTTI/BsAnimationClipRTTI.h
@@ -29,7 +29,7 @@ namespace bs
 			UINT8 version = 0;
 			memory = rttiWriteElem(version, memory, size);
 			memory = rttiWriteElem(data.time, memory, size);
-			memory = rttiWriteElem(data.name, memory, size);
+			rttiWriteElem(data.name, memory, size);
 
 			memcpy(memoryStart, &size, sizeof(UINT32));
 		}
@@ -45,7 +45,7 @@ namespace bs
 			assert(version == 0);
 
 			memory = rttiReadElem(data.time, memory);
-			memory = rttiReadElem(data.name, memory);
+			rttiReadElem(data.name, memory);
 
 			return size;
 		}

--- a/Source/Foundation/bsfCore/Private/RTTI/BsLightProbeVolumeRTTI.h
+++ b/Source/Foundation/bsfCore/Private/RTTI/BsLightProbeVolumeRTTI.h
@@ -41,7 +41,7 @@ namespace bs
 
 			memory = rttiWriteElem(version, memory);
 			memory = rttiWriteElem(data.positions, memory);
-			memory = rttiWriteElem(data.coefficients, memory);
+			rttiWriteElem(data.coefficients, memory);
 		}
 
 		static UINT32 fromMemory(SavedLightProbeInfo& data, char* memory)

--- a/Source/Foundation/bsfCore/Private/RTTI/BsShaderRTTI.h
+++ b/Source/Foundation/bsfCore/Private/RTTI/BsShaderRTTI.h
@@ -15,11 +15,11 @@ namespace bs
 	 */
 
 	template<> struct RTTIPlainType<SHADER_DATA_PARAM_DESC>
-	{	
+	{
 		enum { id = TID_SHADER_DATA_PARAM_DESC }; enum { hasDynamicSize = 1 };
 
 		static void toMemory(const SHADER_DATA_PARAM_DESC& data, char* memory)
-		{ 
+		{
 			UINT32 size = getDynamicSize(data);
 
 			UINT32 curSize = sizeof(UINT32);
@@ -32,13 +32,13 @@ namespace bs
 			memory = rttiWriteElem(data.name, memory);
 			memory = rttiWriteElem(data.gpuVariableName, memory);
 			memory = rttiWriteElem(data.elementSize, memory);
-			memory = rttiWriteElem(data.defaultValueIdx, memory);
+			rttiWriteElem(data.defaultValueIdx, memory);
 		}
 
 		static UINT32 fromMemory(SHADER_DATA_PARAM_DESC& data, char* memory)
-		{ 
+		{
 			UINT32 size;
-			memcpy(&size, memory, sizeof(UINT32)); 
+			memcpy(&size, memory, sizeof(UINT32));
 			memory += sizeof(UINT32);
 
 			memory = rttiReadElem(data.arraySize, memory);
@@ -47,15 +47,15 @@ namespace bs
 			memory = rttiReadElem(data.name, memory);
 			memory = rttiReadElem(data.gpuVariableName, memory);
 			memory = rttiReadElem(data.elementSize, memory);
-			memory = rttiReadElem(data.defaultValueIdx, memory);
+			rttiReadElem(data.defaultValueIdx, memory);
 
 			return size;
 		}
 
-		static UINT32 getDynamicSize(const SHADER_DATA_PARAM_DESC& data)	
-		{ 
+		static UINT32 getDynamicSize(const SHADER_DATA_PARAM_DESC& data)
+		{
 			UINT64 dataSize = rttiGetElemSize(data.arraySize) + rttiGetElemSize(data.rendererSemantic) + rttiGetElemSize(data.type) +
-				rttiGetElemSize(data.name) + rttiGetElemSize(data.gpuVariableName) + rttiGetElemSize(data.elementSize) + 
+				rttiGetElemSize(data.name) + rttiGetElemSize(data.gpuVariableName) + rttiGetElemSize(data.elementSize) +
 				rttiGetElemSize(data.defaultValueIdx) + sizeof(UINT32);
 
 #if BS_DEBUG_MODE
@@ -66,15 +66,15 @@ namespace bs
 #endif
 
 			return (UINT32)dataSize;
-		}	
-	}; 
+		}
+	};
 
 	template<> struct RTTIPlainType<SHADER_OBJECT_PARAM_DESC>
-	{	
+	{
 		enum { id = TID_SHADER_OBJECT_PARAM_DESC }; enum { hasDynamicSize = 1 };
 
 		static void toMemory(const SHADER_OBJECT_PARAM_DESC& data, char* memory)
-		{ 
+		{
 			UINT32 size = getDynamicSize(data);
 
 			UINT32 curSize = sizeof(UINT32);
@@ -85,28 +85,28 @@ namespace bs
 			memory = rttiWriteElem(data.type, memory);
 			memory = rttiWriteElem(data.name, memory);
 			memory = rttiWriteElem(data.gpuVariableNames, memory);
-			memory = rttiWriteElem(data.defaultValueIdx, memory);
+			rttiWriteElem(data.defaultValueIdx, memory);
 		}
 
 		static UINT32 fromMemory(SHADER_OBJECT_PARAM_DESC& data, char* memory)
-		{ 
+		{
 			UINT32 size;
-			memcpy(&size, memory, sizeof(UINT32)); 
+			memcpy(&size, memory, sizeof(UINT32));
 			memory += sizeof(UINT32);
 
 			memory = rttiReadElem(data.rendererSemantic, memory);
 			memory = rttiReadElem(data.type, memory);
 			memory = rttiReadElem(data.name, memory);
 			memory = rttiReadElem(data.gpuVariableNames, memory);
-			memory = rttiReadElem(data.defaultValueIdx, memory);
+			rttiReadElem(data.defaultValueIdx, memory);
 
 			return size;
 		}
 
-		static UINT32 getDynamicSize(const SHADER_OBJECT_PARAM_DESC& data)	
-		{ 
+		static UINT32 getDynamicSize(const SHADER_OBJECT_PARAM_DESC& data)
+		{
 			UINT64 dataSize = rttiGetElemSize(data.rendererSemantic) + rttiGetElemSize(data.type) +
-				rttiGetElemSize(data.name) + rttiGetElemSize(data.gpuVariableNames) + 
+				rttiGetElemSize(data.name) + rttiGetElemSize(data.gpuVariableNames) +
 				rttiGetElemSize(data.defaultValueIdx) + sizeof(UINT32);
 
 #if BS_DEBUG_MODE
@@ -117,15 +117,15 @@ namespace bs
 #endif
 
 			return (UINT32)dataSize;
-		}	
-	}; 
+		}
+	};
 
 	template<> struct RTTIPlainType<SHADER_PARAM_BLOCK_DESC>
-	{	
+	{
 		enum { id = TID_SHADER_PARAM_BLOCK_DESC }; enum { hasDynamicSize = 1 };
 
 		static void toMemory(const SHADER_PARAM_BLOCK_DESC& data, char* memory)
-		{ 
+		{
 			UINT32 size = getDynamicSize(data);
 
 			UINT32 curSize = sizeof(UINT32);
@@ -135,26 +135,26 @@ namespace bs
 			memory = rttiWriteElem(data.shared, memory);
 			memory = rttiWriteElem(data.usage, memory);
 			memory = rttiWriteElem(data.name, memory);
-			memory = rttiWriteElem(data.rendererSemantic, memory);
+			rttiWriteElem(data.rendererSemantic, memory);
 		}
 
 		static UINT32 fromMemory(SHADER_PARAM_BLOCK_DESC& data, char* memory)
-		{ 
+		{
 			UINT32 size;
-			memcpy(&size, memory, sizeof(UINT32)); 
+			memcpy(&size, memory, sizeof(UINT32));
 			memory += sizeof(UINT32);
 
 			memory = rttiReadElem(data.shared, memory);
 			memory = rttiReadElem(data.usage, memory);
 			memory = rttiReadElem(data.name, memory);
-			memory = rttiReadElem(data.rendererSemantic, memory);
+			rttiReadElem(data.rendererSemantic, memory);
 
 			return size;
 		}
 
-		static UINT32 getDynamicSize(const SHADER_PARAM_BLOCK_DESC& data)	
-		{ 
-			UINT64 dataSize = rttiGetElemSize(data.shared) + rttiGetElemSize(data.usage) + 
+		static UINT32 getDynamicSize(const SHADER_PARAM_BLOCK_DESC& data)
+		{
+			UINT64 dataSize = rttiGetElemSize(data.shared) + rttiGetElemSize(data.usage) +
 				rttiGetElemSize(data.name) + rttiGetElemSize(data.rendererSemantic) + sizeof(UINT32);
 
 #if BS_DEBUG_MODE
@@ -165,8 +165,8 @@ namespace bs
 #endif
 
 			return (UINT32)dataSize;
-		}	
-	}; 
+		}
+	};
 
 	class BS_CORE_EXPORT SubShaderRTTI : public RTTIType<SubShader, IReflectable, SubShaderRTTI>
 	{
@@ -175,7 +175,7 @@ namespace bs
 			BS_RTTI_MEMBER_PLAIN(name, 0)
 			BS_RTTI_MEMBER_REFLPTR(shader, 1)
 		BS_END_RTTI_MEMBERS
-		
+
 	public:
 		const String& getRTTIName() override
 		{
@@ -200,7 +200,7 @@ namespace bs
 		BS_BEGIN_RTTI_MEMBERS
 			BS_RTTI_MEMBER_REFLPTR_ARRAY_NAMED(mTechniques, mDesc.techniques, 0)
 			BS_RTTI_MEMBER_PLAIN(mName, 1)
-			
+
 			BS_RTTI_MEMBER_PLAIN_NAMED(mQueueSortType, mDesc.queueSortType, 7)
 			BS_RTTI_MEMBER_PLAIN_NAMED(mQueuePriority, mDesc.queuePriority, 8)
 			BS_RTTI_MEMBER_PLAIN_NAMED(mSeparablePasses, mDesc.separablePasses, 9)
@@ -213,24 +213,24 @@ namespace bs
 			BS_RTTI_MEMBER_REFL_ARRAY_NAMED(mSubShaders, mDesc.subShaders, 14)
 		BS_END_RTTI_MEMBERS
 
-		SHADER_DATA_PARAM_DESC& getDataParam(Shader* obj, UINT32 idx) 
-		{ 
+		SHADER_DATA_PARAM_DESC& getDataParam(Shader* obj, UINT32 idx)
+		{
 			auto iter = obj->mDesc.dataParams.begin();
 			for(UINT32 i = 0; i < idx; i++) ++iter;
 
-			return iter->second; 
+			return iter->second;
 		}
 
 		void setDataParam(Shader* obj, UINT32 idx, SHADER_DATA_PARAM_DESC& val) { obj->mDesc.dataParams[val.name] = val; }
 		UINT32 getDataParamsArraySize(Shader* obj) { return (UINT32)obj->mDesc.dataParams.size(); }
 		void setDataParamsArraySize(Shader* obj, UINT32 size) {  } // Do nothing
 
-		SHADER_OBJECT_PARAM_DESC& getTextureParam(Shader* obj, UINT32 idx) 
-		{ 
+		SHADER_OBJECT_PARAM_DESC& getTextureParam(Shader* obj, UINT32 idx)
+		{
 			auto iter = obj->mDesc.textureParams.begin();
 			for(UINT32 i = 0; i < idx; i++) ++iter;
 
-			return iter->second; 
+			return iter->second;
 		}
 
 		void setTextureParam(Shader* obj, UINT32 idx, SHADER_OBJECT_PARAM_DESC& val) { obj->mDesc.textureParams[val.name] = val; }
@@ -276,7 +276,7 @@ namespace bs
 	public:
 		ShaderRTTI()
 		{
-			addPlainArrayField("mDataParams", 2, &ShaderRTTI::getDataParam, &ShaderRTTI::getDataParamsArraySize, 
+			addPlainArrayField("mDataParams", 2, &ShaderRTTI::getDataParam, &ShaderRTTI::getDataParamsArraySize,
 				&ShaderRTTI::setDataParam, &ShaderRTTI::setDataParamsArraySize);
 			addPlainArrayField("mTextureParams", 3, &ShaderRTTI::getTextureParam, &ShaderRTTI::getTextureParamsArraySize,
 				&ShaderRTTI::setTextureParam, &ShaderRTTI::setTextureParamsArraySize);
@@ -284,7 +284,7 @@ namespace bs
 				&ShaderRTTI::setSamplerParam, &ShaderRTTI::setSamplerParamsArraySize);
 			addPlainArrayField("mBufferParams", 5, &ShaderRTTI::getBufferParam, &ShaderRTTI::getBufferParamsArraySize,
 				&ShaderRTTI::setBufferParam, &ShaderRTTI::setBufferParamsArraySize);
-			addPlainArrayField("mParamBlocks", 6, &ShaderRTTI::getParamBlock, &ShaderRTTI::getParamBlocksArraySize, 
+			addPlainArrayField("mParamBlocks", 6, &ShaderRTTI::getParamBlock, &ShaderRTTI::getParamBlocksArraySize,
 				&ShaderRTTI::setParamBlock, &ShaderRTTI::setParamBlocksArraySize);
 		}
 

--- a/Source/Foundation/bsfCore/Private/RTTI/BsSkeletonRTTI.h
+++ b/Source/Foundation/bsfCore/Private/RTTI/BsSkeletonRTTI.h
@@ -22,7 +22,7 @@ namespace bs
 		void setNumBindPoses(Skeleton* obj, UINT32 size)
 		{
 			obj->mNumBones = size;
-			
+
 			assert(obj->mInvBindPoses == nullptr);
 			obj->mInvBindPoses = bs_newN<Matrix4>(size);
 		}
@@ -44,7 +44,7 @@ namespace bs
 		void setNumBoneTransforms(Skeleton* obj, UINT32 size)
 		{
 			obj->mNumBones = size;
-			
+
 			assert(obj->mBoneTransforms == nullptr);
 			obj->mBoneTransforms = bs_newN<Transform>(size);
 		}
@@ -102,7 +102,7 @@ namespace bs
 			memory = rttiReadElem(size, memory);
 
 			memory = rttiReadElem(data.name, memory);
-			memory = rttiReadElem(data.parent, memory);
+			rttiReadElem(data.parent, memory);
 
 			return size;
 		}

--- a/Source/Foundation/bsfCore/RenderAPI/BsGpuParamBlockBuffer.cpp
+++ b/Source/Foundation/bsfCore/RenderAPI/BsGpuParamBlockBuffer.cpp
@@ -9,9 +9,10 @@ namespace bs
 		:mUsage(usage), mSize(size), mCachedData(nullptr)
 	{
 		if (mSize > 0)
+		{
 			mCachedData = (UINT8*)bs_alloc(mSize);
-
-		memset(mCachedData, 0, mSize);
+			memset(mCachedData, 0, mSize);
+		}
 	}
 
 	GpuParamBlockBuffer::~GpuParamBlockBuffer()
@@ -93,9 +94,10 @@ namespace bs
 		:mUsage(usage), mSize(size), mCachedData(nullptr), mGPUBufferDirty(false)
 	{
 		if (mSize > 0)
+		{
 			mCachedData = (UINT8*)bs_alloc(mSize);
-
-		memset(mCachedData, 0, mSize);
+			memset(mCachedData, 0, mSize);
+		}
 	}
 
 	GpuParamBlockBuffer::~GpuParamBlockBuffer()
@@ -164,7 +166,7 @@ namespace bs
 		write(0, data.getBuffer(), data.getBufferSize());
 	}
 
-	SPtr<GpuParamBlockBuffer> GpuParamBlockBuffer::create(UINT32 size, GpuParamBlockUsage usage, 
+	SPtr<GpuParamBlockBuffer> GpuParamBlockBuffer::create(UINT32 size, GpuParamBlockUsage usage,
 		GpuDeviceFlags deviceMask)
 	{
 		return HardwareBufferManager::instance().createGpuParamBlockBuffer(size, usage, deviceMask);

--- a/Source/Foundation/bsfCore/RenderAPI/BsGpuParamDesc.h
+++ b/Source/Foundation/bsfCore/RenderAPI/BsGpuParamDesc.h
@@ -73,12 +73,12 @@ namespace bs
 	 */
 
 	template<> struct RTTIPlainType<GpuParamDataDesc>
-	{	
+	{
 		enum { id = TID_GpuParamDataDesc }; enum { hasDynamicSize = 1 };
 		static constexpr UINT32 VERSION = 1;
 
 		static void toMemory(const GpuParamDataDesc& data, char* memory)
-		{ 
+		{
 			UINT32 size = getDynamicSize(data);
 
 			UINT32 curSize = sizeof(UINT32);
@@ -96,13 +96,13 @@ namespace bs
 			memory = rttiWriteElem(data.paramBlockSlot, memory);
 			memory = rttiWriteElem(data.paramBlockSet, memory);
 			memory = rttiWriteElem(data.gpuMemOffset, memory);
-			memory = rttiWriteElem(data.cpuMemOffset, memory);
+			rttiWriteElem(data.cpuMemOffset, memory);
 		}
 
 		static UINT32 fromMemory(GpuParamDataDesc& data, char* memory)
-		{ 
+		{
 			UINT32 size;
-			memcpy(&size, memory, sizeof(UINT32)); 
+			memcpy(&size, memory, sizeof(UINT32));
 			memory += sizeof(UINT32);
 
 			UINT32 version = 0;
@@ -118,29 +118,29 @@ namespace bs
 			memory = rttiReadElem(data.paramBlockSlot, memory);
 			memory = rttiReadElem(data.paramBlockSet, memory);
 			memory = rttiReadElem(data.gpuMemOffset, memory);
-			memory = rttiReadElem(data.cpuMemOffset, memory);
+			rttiReadElem(data.cpuMemOffset, memory);
 
 			return size;
 		}
 
-		static UINT32 getDynamicSize(const GpuParamDataDesc& data)	
-		{ 
+		static UINT32 getDynamicSize(const GpuParamDataDesc& data)
+		{
 			UINT32 dataSize = rttiGetElemSize(VERSION) + rttiGetElemSize(data.name) + rttiGetElemSize(data.elementSize) +
-				rttiGetElemSize(data.arraySize) + rttiGetElemSize(data.arrayElementStride) + rttiGetElemSize(data.type) + 
-				rttiGetElemSize(data.paramBlockSlot) + rttiGetElemSize(data.paramBlockSet) + 
+				rttiGetElemSize(data.arraySize) + rttiGetElemSize(data.arrayElementStride) + rttiGetElemSize(data.type) +
+				rttiGetElemSize(data.paramBlockSlot) + rttiGetElemSize(data.paramBlockSet) +
 				rttiGetElemSize(data.gpuMemOffset) + rttiGetElemSize(data.cpuMemOffset) + sizeof(UINT32);
 
 			return dataSize;
-		}	
-	}; 
+		}
+	};
 
 	template<> struct RTTIPlainType<GpuParamObjectDesc>
-	{	
+	{
 		enum { id = TID_GpuParamObjectDesc }; enum { hasDynamicSize = 1 };
 		static constexpr UINT32 VERSION = 1;
 
 		static void toMemory(const GpuParamObjectDesc& data, char* memory)
-		{ 
+		{
 			UINT32 size = getDynamicSize(data);
 
 			UINT32 curSize = sizeof(UINT32);
@@ -152,13 +152,13 @@ namespace bs
 			memory = rttiWriteElem(data.name, memory);
 			memory = rttiWriteElem(data.type, memory);
 			memory = rttiWriteElem(data.slot, memory);
-			memory = rttiWriteElem(data.set, memory);
+			rttiWriteElem(data.set, memory);
 		}
 
 		static UINT32 fromMemory(GpuParamObjectDesc& data, char* memory)
-		{ 
+		{
 			UINT32 size;
-			memcpy(&size, memory, sizeof(UINT32)); 
+			memcpy(&size, memory, sizeof(UINT32));
 			memory += sizeof(UINT32);
 
 			UINT32 version = 0;
@@ -168,27 +168,27 @@ namespace bs
 			memory = rttiReadElem(data.name, memory);
 			memory = rttiReadElem(data.type, memory);
 			memory = rttiReadElem(data.slot, memory);
-			memory = rttiReadElem(data.set, memory);
+			rttiReadElem(data.set, memory);
 
 			return size;
 		}
 
-		static UINT32 getDynamicSize(const GpuParamObjectDesc& data)	
-		{ 
+		static UINT32 getDynamicSize(const GpuParamObjectDesc& data)
+		{
 			UINT32 dataSize = rttiGetElemSize(VERSION) + rttiGetElemSize(data.name) + rttiGetElemSize(data.type) +
 				rttiGetElemSize(data.slot) + rttiGetElemSize(data.set) + sizeof(UINT32);
 
 			return dataSize;
-		}	
-	}; 
+		}
+	};
 
 	template<> struct RTTIPlainType<GpuParamBlockDesc>
-	{	
+	{
 		enum { id = TID_GpuParamBlockDesc }; enum { hasDynamicSize = 1 };
 		static constexpr UINT32 VERSION = 1;
 
 		static void toMemory(const GpuParamBlockDesc& data, char* memory)
-		{ 
+		{
 			UINT32 size = getDynamicSize(data);
 
 			UINT32 curSize = sizeof(UINT32);
@@ -201,13 +201,13 @@ namespace bs
 			memory = rttiWriteElem(data.set, memory);
 			memory = rttiWriteElem(data.slot, memory);
 			memory = rttiWriteElem(data.blockSize, memory);
-			memory = rttiWriteElem(data.isShareable, memory);
+			rttiWriteElem(data.isShareable, memory);
 		}
 
 		static UINT32 fromMemory(GpuParamBlockDesc& data, char* memory)
-		{ 
+		{
 			UINT32 size;
-			memcpy(&size, memory, sizeof(UINT32)); 
+			memcpy(&size, memory, sizeof(UINT32));
 			memory += sizeof(UINT32);
 
 			UINT32 version = 0;
@@ -218,20 +218,20 @@ namespace bs
 			memory = rttiReadElem(data.set, memory);
 			memory = rttiReadElem(data.slot, memory);
 			memory = rttiReadElem(data.blockSize, memory);
-			memory = rttiReadElem(data.isShareable, memory);
+			rttiReadElem(data.isShareable, memory);
 
 			return size;
 		}
 
 		static UINT32 getDynamicSize(const GpuParamBlockDesc& data)
-		{ 
+		{
 			UINT32 dataSize = rttiGetElemSize(VERSION) + rttiGetElemSize(data.name) + rttiGetElemSize(data.set) +
-				rttiGetElemSize(data.slot) + rttiGetElemSize(data.blockSize) + rttiGetElemSize(data.isShareable) + 
+				rttiGetElemSize(data.slot) + rttiGetElemSize(data.blockSize) + rttiGetElemSize(data.isShareable) +
 				sizeof(UINT32);
 
 			return dataSize;
-		}	
-	}; 
+		}
+	};
 
 	/** @} */
 	/** @endcond */

--- a/Source/Foundation/bsfCore/Text/BsFontDesc.h
+++ b/Source/Foundation/bsfCore/Text/BsFontDesc.h
@@ -39,11 +39,11 @@ namespace bs
 
 	// Make CHAR_DESC serializable
 	template<> struct RTTIPlainType<CharDesc>
-	{	
+	{
 		enum { id = TID_CHAR_DESC }; enum { hasDynamicSize = 1 };
 
 		static void toMemory(const CharDesc& data, char* memory)
-		{ 
+		{
 			UINT32 size = getDynamicSize(data);
 
 			memcpy(memory, &size, sizeof(UINT32));
@@ -61,13 +61,13 @@ namespace bs
 			memory = rttiWriteElem(data.yOffset, memory);
 			memory = rttiWriteElem(data.xAdvance, memory);
 			memory = rttiWriteElem(data.yAdvance, memory);
-			memory = rttiWriteElem(data.kerningPairs, memory);
+			rttiWriteElem(data.kerningPairs, memory);
 		}
 
 		static UINT32 fromMemory(CharDesc& data, char* memory)
-		{ 
+		{
 			UINT32 size;
-			memcpy(&size, memory, sizeof(UINT32)); 
+			memcpy(&size, memory, sizeof(UINT32));
 			memory += sizeof(UINT32);
 
 			memory = rttiReadElem(data.charId, memory);
@@ -82,13 +82,13 @@ namespace bs
 			memory = rttiReadElem(data.yOffset, memory);
 			memory = rttiReadElem(data.xAdvance, memory);
 			memory = rttiReadElem(data.yAdvance, memory);
-			memory = rttiReadElem(data.kerningPairs, memory);
+			rttiReadElem(data.kerningPairs, memory);
 
 			return size;
 		}
 
-		static UINT32 getDynamicSize(const CharDesc& data)	
-		{ 
+		static UINT32 getDynamicSize(const CharDesc& data)
+		{
 			UINT64 dataSize = sizeof(data.charId)
 				+ sizeof(data.page)
 				+ sizeof(data.uvX)
@@ -106,8 +106,8 @@ namespace bs
 			dataSize += sizeof(UINT32);
 
 			return (UINT32)dataSize;
-		}	
-	}; 
+		}
+	};
 
 	/** @endcond */
 	/** @} */

--- a/Source/Foundation/bsfUtility/FileSystem/BsPath.h
+++ b/Source/Foundation/bsfUtility/FileSystem/BsPath.h
@@ -13,12 +13,12 @@ namespace bs
 	 */
 
 	/**
-	 * Class for storing and manipulating file paths. Paths may be parsed from and to raw strings according to various 
+	 * Class for storing and manipulating file paths. Paths may be parsed from and to raw strings according to various
 	 * platform specific path types.
 	 *
-	 * @note	
+	 * @note
 	 * In order to allow the system to easily distinguish between file and directory paths, try to ensure that all directory
-	 * paths end with a separator (\ or / depending on platform). System won't fail if you don't but it will be easier to 
+	 * paths end with a separator (\ or / depending on platform). System won't fail if you don't but it will be easier to
 	 * misuse.
 	 */
 	class BS_UTILITY_EXPORT Path
@@ -45,7 +45,7 @@ namespace bs
 		Path(const String& pathStr, PathType type = PathType::Default);
 
 		/**
-		 * Constructs a path by parsing the provided path null terminated string. Throws exception if provided path is 
+		 * Constructs a path by parsing the provided path null terminated string. Throws exception if provided path is
 		 * not valid.
 		 *
 		 * @param[in]	pathStr	Null-terminated string containing the path. Ideally this should be an UTF-8 encoded string
@@ -57,13 +57,13 @@ namespace bs
 		Path(const Path& other);
 
 		/**
-		 * Assigns a path by parsing the provided path string. Path will be parsed according to the rules of the platform 
+		 * Assigns a path by parsing the provided path string. Path will be parsed according to the rules of the platform
 		 * the application is being compiled to.
 		 */
 		Path& operator= (const String& pathStr);
 
 		/**
-		 * Assigns a path by parsing the provided path null terminated string. Path will be parsed according to the rules 
+		 * Assigns a path by parsing the provided path null terminated string. Path will be parsed according to the rules
 		 * of the platform the application is being compiled to.
 		 */
 		Path& operator= (const char* pathStr);
@@ -71,13 +71,13 @@ namespace bs
 		Path& operator= (const Path& path);
 
 		/**
-		 * Compares two paths and returns true if they match. Comparison is case insensitive and paths will be compared 
+		 * Compares two paths and returns true if they match. Comparison is case insensitive and paths will be compared
 		 * as-is, without canonization.
 		 */
 		bool operator== (const Path& path) const { return equals(path); }
 
 		/**
-		 * Compares two paths and returns true if they don't match. Comparison is case insensitive and paths will be 
+		 * Compares two paths and returns true if they don't match. Comparison is case insensitive and paths will be
 		 * compared as-is, without canonization.
 		 */
 		bool operator!= (const Path& path) const { return !equals(path); }
@@ -95,13 +95,13 @@ namespace bs
 		 * Constructs a path by parsing the provided path string. Throws exception if provided path is not valid.
 		 *
 		 * @param[in]	pathStr	String containing the path.
-		 * @param[in]	type	If set to default path will be parsed according to the rules of the platform the application 
+		 * @param[in]	type	If set to default path will be parsed according to the rules of the platform the application
 		 *						is being compiled to. Otherwise it will be parsed according to provided type.
 		 */
 		void assign(const String& pathStr, PathType type = PathType::Default);
 
 		/**
-		 * Constructs a path by parsing the provided path null terminated string. Throws exception if provided path is not 
+		 * Constructs a path by parsing the provided path null terminated string. Throws exception if provided path is not
 		 * valid.
 		 *
 		 * @param[in]	pathStr		Null-terminated string containing the path.
@@ -114,7 +114,7 @@ namespace bs
 		/**
 		 * Converts the path in a string according to platform path rules.
 		 *
-		 * @param[in] type	If set to default path will be parsed according to the rules of the platform the application is 
+		 * @param[in] type	If set to default path will be parsed according to the rules of the platform the application is
 		 *					being compiled to. Otherwise it will be parsed according to provided type.
 		 * @return			String representing the path using the UTF8 string encoding.
 		 */
@@ -142,46 +142,46 @@ namespace bs
 
 		/**
 		 * Returns parent path. If current path points to a file the parent path will be the folder where the file is located.
-		 * Or if it contains a directory the parent will be the parent directory. If no parent exists, same path will be 
+		 * Or if it contains a directory the parent will be the parent directory. If no parent exists, same path will be
 		 * returned.
 		 */
 		Path getParent() const;
 
 		/**
-		 * Returns an absolute path by appending the current path to the provided base. If path was already absolute no 
-		 * changes are made and copy of current path is returned. If base is not absolute, then the returned path will be 
+		 * Returns an absolute path by appending the current path to the provided base. If path was already absolute no
+		 * changes are made and copy of current path is returned. If base is not absolute, then the returned path will be
 		 * made relative to base, but will not be absolute.
 		 */
 		Path getAbsolute(const Path& base) const;
 
 		/**
-		 * Returns a relative path by making the current path relative to the provided base. Base must be a part of the 
+		 * Returns a relative path by making the current path relative to the provided base. Base must be a part of the
 		 * current path. If base is not a part of the path no changes are made and a copy of the current path is returned.
 		 */
 		Path getRelative(const Path& base) const;
 
 		/**
-		 * Returns the path as a path to directory. If path was pointing to a file, the filename is removed, otherwise no 
+		 * Returns the path as a path to directory. If path was pointing to a file, the filename is removed, otherwise no
 		 * changes are made and exact copy is returned.
 		 */
 		Path getDirectory() const;
 
 		/**
-		 * Makes the path the parent of the current path. If current path points to a file the parent path will be the 
-		 * folder where the file is located. Or if it contains a directory the parent will be the parent directory. If no 
+		 * Makes the path the parent of the current path. If current path points to a file the parent path will be the
+		 * folder where the file is located. Or if it contains a directory the parent will be the parent directory. If no
 		 * parent exists, same path will be returned.
 		 */
 		Path& makeParent();
 
 		/**
-		 * Makes the current path absolute by appending it to base. If path was already absolute no changes are made and 
+		 * Makes the current path absolute by appending it to base. If path was already absolute no changes are made and
 		 * copy of current path is returned. If base is not absolute, then the returned path will be made relative to base,
 		 * but will not be absolute.
 		 */
 		Path& makeAbsolute(const Path& base);
 
 		/**
-		 * Makes the current path relative to the provided base. Base must be a part of the current path. If base is not 
+		 * Makes the current path relative to the provided base. Base must be a part of the current path. If base is not
 		 * a part of the path no changes are made and a copy of the current path is returned.
 		 */
 		Path& makeRelative(const Path& base);
@@ -190,13 +190,13 @@ namespace bs
 		Path& append(const Path& path);
 
 		/**
-		 * Checks if the current path contains the provided path. Comparison is case insensitive and paths will be compared 
+		 * Checks if the current path contains the provided path. Comparison is case insensitive and paths will be compared
 		 * as-is, without canonization.
 		 */
 		bool includes(const Path& child) const;
 
 		/**
-		 * Compares two paths and returns true if they match. Comparison is case insensitive and paths will be compared 
+		 * Compares two paths and returns true if they match. Comparison is case insensitive and paths will be compared
 		 * as-is, without canonization.
 		 */
 		bool equals(const Path& other) const;
@@ -205,7 +205,7 @@ namespace bs
 		void setFilename(const String& filename) { mFilename = filename; }
 
 		/**
-		 * Change or set the base name in the path. Base name changes the filename by changing its base to the provided 
+		 * Change or set the base name in the path. Base name changes the filename by changing its base to the provided
 		 * value but keeping extension intact.
 		 */
 		void setBasename(const String& basename);
@@ -240,7 +240,7 @@ namespace bs
 		const String& getNode() const { return mNode; }
 
 		/**
-		 * Gets last element in the path, filename if it exists, otherwise the last directory. If no directories exist 
+		 * Gets last element in the path, filename if it exists, otherwise the last directory. If no directories exist
 		 * returns device or node.
 		 */
 		const String& getTail() const;
@@ -472,7 +472,7 @@ namespace bs
 			memory = rttiWriteElem(data.mNode, memory);
 			memory = rttiWriteElem(data.mFilename, memory);
 			memory = rttiWriteElem(data.mIsAbsolute, memory);
-			memory = rttiWriteElem(data.mDirectories, memory);
+			rttiWriteElem(data.mDirectories, memory);
 		}
 
 		static UINT32 fromMemory(Path& data, char* memory)
@@ -485,7 +485,7 @@ namespace bs
 			memory = rttiReadElem(data.mNode, memory);
 			memory = rttiReadElem(data.mFilename, memory);
 			memory = rttiReadElem(data.mIsAbsolute, memory);
-			memory = rttiReadElem(data.mDirectories, memory);
+			rttiReadElem(data.mDirectories, memory);
 
 			return size;
 		}


### PR DESCRIPTION
Clang static analyzer was complaining about those:
* assigning values to `memory = ` and not using them at all
* possible memset with nullptr, and size 0, just to be on the safe side
moved them inside the corresponding `if`