### PR TITLE
Make NativePtrs comparison operators live outside the class, so that they can be constexpr.

### DIFF
--- a/Source/Foundation/bsfUtility/Prerequisites/BsStdHeaders.h
+++ b/Source/Foundation/bsfUtility/Prerequisites/BsStdHeaders.h
@@ -216,6 +216,11 @@ namespace bs
 		return bs_unique_ptr<Type, Alloc, Deleter>(rawPtr);
 	}
 
+	/**
+	 * "Smart" pointer that is not smart. Does nothing but hold a pointer value. No memory management is performed at all.
+	 * This class exists to make storing pointers in containers easier to manage, such as with non-member comparison
+	 * operators.
+	 */
 	template<typename T>
 	struct NativePtr
 	{
@@ -223,24 +228,49 @@ namespace bs
 		constexpr T& operator*() const { return *mPtr; }
 		constexpr T* operator->() const { return mPtr; }
 		constexpr T* get() const { return mPtr; }
-		bool operator< (const NativePtr& rhs) const { return mPtr <  rhs.mPtr; }
-		bool operator> (const NativePtr& rhs) const { return mPtr >  rhs.mPtr; }
-		bool operator<=(const NativePtr& rhs) const { return mPtr <= rhs.mPtr; }
-		bool operator>=(const NativePtr& rhs) const { return mPtr >= rhs.mPtr; }
-		bool operator==(const NativePtr& rhs) const { return mPtr == rhs.mPtr; }
-		bool operator!=(const NativePtr& rhs) const { return mPtr != rhs.mPtr; }
 
 	private:
 		T* mPtr = nullptr;
 	};
 
-	/**
-	 * "Smart" pointer that is not smart. Does nothing but hold a pointer value. No memory management is performed at all.
-	 * This class exists to make storing pointers in containers easier to manage, such as with non-member comparison
-	 * operators.
-	 */
-	template <typename T>
+	template<typename T>
 	using NPtr = NativePtr<T>;
+
+	template<typename L_T, typename R_T>
+	constexpr bool operator< (const NPtr<L_T>& lhs, const NPtr<R_T>& rhs)
+	{
+		 return lhs.get() < rhs.get();
+	}
+
+	template<typename L_T, typename R_T>
+	constexpr bool operator> (const NPtr<L_T>& lhs, const NPtr<R_T>& rhs)
+	{
+		 return lhs.get() > rhs.get();
+	}
+
+	template<typename L_T, typename R_T>
+	constexpr bool operator<= (const NPtr<L_T>& lhs, const NPtr<R_T>& rhs)
+	{
+		 return lhs.get() <= rhs.get();
+	}
+
+	template<typename L_T, typename R_T>
+	constexpr bool operator>= (const NPtr<L_T>& lhs, const NPtr<R_T>& rhs)
+	{
+		 return lhs.get() >= rhs.get();
+	}
+
+	template<typename L_T, typename R_T>
+	constexpr bool operator== (const NPtr<L_T>& lhs, const NPtr<R_T>& rhs)
+	{
+		 return lhs.get() == rhs.get();
+	}
+
+	template<typename L_T, typename R_T>
+	constexpr bool operator!= (const NPtr<L_T>& lhs, const NPtr<R_T>& rhs)
+	{
+		 return lhs.get() != rhs.get();
+	}
 
 	/** @} */
 }

--- a/Source/Foundation/bsfUtility/Utility/BsDynLibManager.cpp
+++ b/Source/Foundation/bsfUtility/Utility/BsDynLibManager.cpp
@@ -14,10 +14,11 @@ namespace bs
 	{
 		return lhs < rhs->getName();
 	}
-	template<>
-	bool NPtr<DynLib>::operator<(const NPtr<DynLib>& rhs) const {
-		return mPtr->getName() < rhs->getName();
+	static bool operator<(const NPtr<DynLib>& lhs, const NPtr<DynLib>& rhs)
+	{
+		return lhs->getName() < rhs->getName();
 	}
+
 	DynLib* DynLibManager::load(String filename)
 	{
 		// Add the extension (.dll, .so, ...) if necessary.


### PR DESCRIPTION
Lets try this rodeo one more time :-)

Now NativePtr's comparison operators aren't member functions, freeing up template specializations from forcing the default implementation to be non-constexpr.

Until Visual Studio's implementation of std::set supports UniquePtr (which, btw, the most recent update may have fixed that, and now that VS2015 isn't supported anymore, I'll investigate that again), this should be the final word on the whole dynlib situation.