### PR TITLE
Use UPtr to manage DynLib lifetimes inside of BsDynLibManager.

### DIFF
--- a/Source/Foundation/bsfUtility/Utility/BsDynLibManager.cpp
+++ b/Source/Foundation/bsfUtility/Utility/BsDynLibManager.cpp
@@ -5,16 +5,27 @@
 
 namespace bs
 {
-	static bool operator<(const NPtr<DynLib>& lhs, const String& rhs)
+
+namespace
+{
+	static void dynlib_delete(DynLib* lib)
+	{
+		lib->unload();
+		bs_delete(lib);
+	}
+} // namespace ()
+
+	static bool operator<(const UPtr<DynLib>& lhs, const String& rhs)
 	{
 		return lhs->getName() < rhs;
 	}
 
-	static bool operator<(const String& lhs, const NPtr<DynLib>& rhs)
+	static bool operator<(const String& lhs, const UPtr<DynLib>& rhs)
 	{
 		return lhs < rhs->getName();
 	}
-	static bool operator<(const NPtr<DynLib>& lhs, const NPtr<DynLib>& rhs)
+
+	static bool operator<(const UPtr<DynLib>& lhs, const UPtr<DynLib>& rhs)
 	{
 		return lhs->getName() < rhs->getName();
 	}
@@ -28,21 +39,21 @@ namespace bs
 		const String::size_type length = filename.length();
 		const String extension = String(".") + DynLib::EXTENSION;
 		const String::size_type extLength = extension.length();
-		if (length <= extLength || filename.substr(length - extLength) != extension)
+		if(length <= extLength || filename.substr(length - extLength) != extension)
 			filename.append(extension);
 
 		if(DynLib::PREFIX != nullptr)
 			filename.insert(0, DynLib::PREFIX);
 
 		const auto& iterFind = mLoadedLibraries.lower_bound(filename);
-		if (iterFind != mLoadedLibraries.end() && (*iterFind)->getName() == filename)
+		if(iterFind != mLoadedLibraries.end() && (*iterFind)->getName() == filename)
 		{
 			return iterFind->get();
 		}
 		else
 		{
 			DynLib* newLib = bs_new<DynLib>(std::move(filename));
-			mLoadedLibraries.emplace_hint(iterFind, newLib);
+			mLoadedLibraries.emplace_hint(iterFind, newLib, &dynlib_delete);
 			return newLib;
 		}
 	}
@@ -50,26 +61,16 @@ namespace bs
 	void DynLibManager::unload(DynLib* lib)
 	{
 		const auto& iterFind = mLoadedLibraries.find(lib->getName());
-		if (iterFind != mLoadedLibraries.end())
+		if(iterFind != mLoadedLibraries.end())
 		{
 			mLoadedLibraries.erase(iterFind);
 		}
-
-		lib->unload();
-		bs_delete(lib);
-	}
-
-	DynLibManager::~DynLibManager()
-	{
-		// Unload & delete each resource in turn
-		for(auto& entry : mLoadedLibraries)
+		else
 		{
-			entry->unload();
-			bs_delete(entry.get());
+			// Somehow a DynLib not owned by the manager...?
+			// Well, we should clean it up anyway...
+			dynlib_delete(lib);
 		}
-
-		// Empty the list
-		mLoadedLibraries.clear();
 	}
 
 	DynLibManager& gDynLibManager()

--- a/Source/Foundation/bsfUtility/Utility/BsDynLibManager.h
+++ b/Source/Foundation/bsfUtility/Utility/BsDynLibManager.h
@@ -12,7 +12,7 @@ namespace bs
 	 */
 
 	/**
-	 * This manager keeps track of all the open dynamic-loading libraries, it manages opening them opens them and can be 
+	 * This manager keeps track of all the open dynamic-loading libraries, it manages opening them opens them and can be
 	 * used to lookup already already-open libraries.
 	 *
 	 * @note	Not thread safe.
@@ -20,9 +20,6 @@ namespace bs
 	class BS_UTILITY_EXPORT DynLibManager : public Module<DynLibManager>
 	{
 	public:
-		DynLibManager() = default;
-		virtual ~DynLibManager();
-
 		/**
 		 * Loads the given file as a dynamic library.
 		 *
@@ -34,7 +31,7 @@ namespace bs
 		void unload(DynLib* lib);
 
 	protected:
-		Set<NPtr<DynLib>, std::less<>> mLoadedLibraries;
+		Set<UPtr<DynLib>, std::less<>> mLoadedLibraries;
 	};
 
 	/** Easy way of accessing DynLibManager. */


### PR DESCRIPTION
The problem that was causing this to work in Linux but not VS2017 is two fold.

1) Gcc defines the copy constructor for std::set as "default", which allows for them to be disabled in situations where the items inside the set aren't copyable, but VS2017 doesn't. They explicitly define them.

2) BsModules was set to have a default copy constructor, which meant that std::set had it's copy-constructor explicitly used in that default copy-constructor.

By disabling the copy and move constructors for BsModules, we eliminate half of the one-two-punch.

So now we can use UniquePtr to manage the lifetime of loaded DynLib objects.