### PR TITLE
Remove redundant check in PrefabDiff::generateDiff

### DIFF
--- a/Source/Foundation/bsfCore/Scene/BsPrefabDiff.cpp
+++ b/Source/Foundation/bsfCore/Scene/BsPrefabDiff.cpp
@@ -39,7 +39,7 @@ namespace bs
 		// would be more efficient to do it once outside of this method. I'm keeping it this way for simplicity for now.
 
 		// Rename instance objects so they share the same IDs as the prefab objects (if they link IDs match). This allows
-		// game object handle diff to work properly, because otherwise handles that point to same objects would be 
+		// game object handle diff to work properly, because otherwise handles that point to same objects would be
 		// marked as different because the instance IDs of the two objects don't match (since one is in prefab and one
 		// in instance).
 		Vector<RenamedGameObject> renamedObjects;
@@ -81,7 +81,7 @@ namespace bs
 			object->setActive(diff->isActive);
 
 		// Note: It is important to remove objects and components first, before adding them.
-		//		 Some systems rely on the fact that applyDiff added components/objects are 
+		//		 Some systems rely on the fact that applyDiff added components/objects are
 		//       always at the end.
 		const Vector<HComponent>& components = object->getComponents();
 		for (auto& removedId : diff->removedComponents)
@@ -162,9 +162,7 @@ namespace bs
 
 		if (prefab->getName() != instance->getName())
 		{
-			if (output == nullptr)
-				output = bs_shared_ptr_new<PrefabObjectDiff>();
-
+			output = bs_shared_ptr_new<PrefabObjectDiff>();
 			output->name = instance->getName();
 			output->soFlags |= (UINT32)SceneObjectDiffFlags::Name;
 		}
@@ -247,7 +245,7 @@ namespace bs
 					output = bs_shared_ptr_new<PrefabObjectDiff>();
 
 				output->removedChildren.push_back(prefabChild->getLinkId());
-			}	
+			}
 		}
 
 		// Find added children


### PR DESCRIPTION
Since output is uninitialized, the comparison `if (output == nullptr)` will always be true