### PR TITLE
Isolate All Build Artifacts into Build Directory

### DIFF
--- a/Source/CMake/Modules/FindFBXSDK.cmake
+++ b/Source/CMake/Modules/FindFBXSDK.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(FBXSDK)
 
-set(FBXSDK_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/FBXSDK CACHE PATH "")
+set(FBXSDK_INSTALL_DIR ${BS_DEPENDENCY_DIR}/FBXSDK CACHE PATH "")
 gen_default_lib_search_dirs(FBXSDK)
 
 if(WIN32)

--- a/Source/CMake/Modules/FindFLAC.cmake
+++ b/Source/CMake/Modules/FindFLAC.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(FLAC)
 
-set(FLAC_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/libFLAC CACHE PATH "")
+set(FLAC_INSTALL_DIR ${BS_DEPENDENCY_DIR}/libFLAC CACHE PATH "")
 gen_default_lib_search_dirs(FLAC)
 
 if(WIN32)

--- a/Source/CMake/Modules/FindFMOD.cmake
+++ b/Source/CMake/Modules/FindFMOD.cmake
@@ -10,7 +10,7 @@ start_find_package(FMOD)
 if(WIN32)
 	set(FMOD_INSTALL_DIR "C:/Program Files (x86)/FMOD SoundSystem/FMOD Studio API Windows" CACHE PATH "")
 else()
-	set(FMOD_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/FMOD CACHE PATH "")
+	set(FMOD_INSTALL_DIR ${BS_DEPENDENCY_DIR}/FMOD CACHE PATH "")
 endif()
 
 gen_default_lib_search_dirs(FMOD)

--- a/Source/CMake/Modules/FindLibICU.cmake
+++ b/Source/CMake/Modules/FindLibICU.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(LibICU)
 
-set(LibICU_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/libICU CACHE PATH "")
+set(LibICU_INSTALL_DIR ${BS_DEPENDENCY_DIR}/libICU CACHE PATH "")
 gen_default_lib_search_dirs(LibICU)
 
 find_imported_includes(LibICU unicode/utypes.h)

--- a/Source/CMake/Modules/FindOpenAL.cmake
+++ b/Source/CMake/Modules/FindOpenAL.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(OpenAL)
 
-set(OpenAL_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/OpenAL CACHE PATH "")
+set(OpenAL_INSTALL_DIR ${BS_DEPENDENCY_DIR}/OpenAL CACHE PATH "")
 gen_default_lib_search_dirs(OpenAL)
 
 if(WIN32)

--- a/Source/CMake/Modules/FindPhysX.cmake
+++ b/Source/CMake/Modules/FindPhysX.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(PhysX)
 
-set(PhysX_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/PhysX CACHE PATH "")
+set(PhysX_INSTALL_DIR ${BS_DEPENDENCY_DIR}/PhysX CACHE PATH "")
 gen_default_lib_search_dirs(PhysX)
 
 if(NOT APPLE)

--- a/Source/CMake/Modules/FindXShaderCompiler.cmake
+++ b/Source/CMake/Modules/FindXShaderCompiler.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(XShaderCompiler)
 
-set(XShaderCompiler_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/XShaderCompiler CACHE PATH "")
+set(XShaderCompiler_INSTALL_DIR ${BS_DEPENDENCY_DIR}/XShaderCompiler CACHE PATH "")
 gen_default_lib_search_dirs(XShaderCompiler)
 
 find_imported_includes(XShaderCompiler Xsc/Xsc.h)

--- a/Source/CMake/Modules/Findbison.cmake
+++ b/Source/CMake/Modules/Findbison.cmake
@@ -4,7 +4,7 @@
 #  bison_EXECUTABLE
 #  bison_FOUND
 
-set(bison_INSTALL_DIRS ${BSF_SOURCE_DIR}/../Dependencies/tools/bison CACHE PATH "")
+set(bison_INSTALL_DIRS ${BS_DEPENDENCY_DIR}/tools/bison CACHE PATH "")
 
 message(STATUS "Looking for bison installation...")
 

--- a/Source/CMake/Modules/Findflex.cmake
+++ b/Source/CMake/Modules/Findflex.cmake
@@ -4,7 +4,7 @@
 #  flex_EXECUTABLE
 #  flex_FOUND
 
-set(flex_INSTALL_DIRS ${BSF_SOURCE_DIR}/../Dependencies/tools/flex CACHE PATH "")
+set(flex_INSTALL_DIRS ${BS_DEPENDENCY_DIR}/tools/flex CACHE PATH "")
 
 message(STATUS "Looking for flex installation...")
 

--- a/Source/CMake/Modules/Findfreeimg.cmake
+++ b/Source/CMake/Modules/Findfreeimg.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(freeimg)
 
-set(freeimg_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/freeimg CACHE PATH "")
+set(freeimg_INSTALL_DIR ${BS_DEPENDENCY_DIR}/freeimg CACHE PATH "")
 gen_default_lib_search_dirs(freeimg)
 
 find_imported_includes(freeimg FreeImage.h)

--- a/Source/CMake/Modules/Findfreetype.cmake
+++ b/Source/CMake/Modules/Findfreetype.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(freetype)
 
-set(freetype_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/freetype CACHE PATH "")
+set(freetype_INSTALL_DIR ${BS_DEPENDENCY_DIR}/freetype CACHE PATH "")
 gen_default_lib_search_dirs(freetype)
 
 list(APPEND freetype_INCLUDE_SEARCH_DIRS /usr/local/include/freetype2)

--- a/Source/CMake/Modules/Findglslang.cmake
+++ b/Source/CMake/Modules/Findglslang.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(glslang)
 
-set(glslang_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/glslang CACHE PATH "")
+set(glslang_INSTALL_DIR ${BS_DEPENDENCY_DIR}/glslang CACHE PATH "")
 gen_default_lib_search_dirs(glslang)
 
 if(WIN32)

--- a/Source/CMake/Modules/Findnvtt.cmake
+++ b/Source/CMake/Modules/Findnvtt.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(nvtt)
 
-set(nvtt_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/nvtt CACHE PATH "")
+set(nvtt_INSTALL_DIR ${BS_DEPENDENCY_DIR}/nvtt CACHE PATH "")
 gen_default_lib_search_dirs(nvtt)
 
 find_imported_includes(nvtt nvtt.h)

--- a/Source/CMake/Modules/Findogg.cmake
+++ b/Source/CMake/Modules/Findogg.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(ogg)
 
-set(ogg_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/libogg CACHE PATH "")
+set(ogg_INSTALL_DIR ${BS_DEPENDENCY_DIR}/libogg CACHE PATH "")
 gen_default_lib_search_dirs(ogg)
 
 if(WIN32)

--- a/Source/CMake/Modules/Findsnappy.cmake
+++ b/Source/CMake/Modules/Findsnappy.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(snappy)
 
-set(snappy_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/snappy CACHE PATH "")
+set(snappy_INSTALL_DIR ${BS_DEPENDENCY_DIR}/snappy CACHE PATH "")
 gen_default_lib_search_dirs(snappy)
 
 find_imported_includes(snappy snappy.h)

--- a/Source/CMake/Modules/Findvorbis.cmake
+++ b/Source/CMake/Modules/Findvorbis.cmake
@@ -7,7 +7,7 @@
 
 start_find_package(vorbis)
 
-set(vorbis_INSTALL_DIR ${BSF_SOURCE_DIR}/../Dependencies/libvorbis CACHE PATH "")
+set(vorbis_INSTALL_DIR ${BS_DEPENDENCY_DIR}/libvorbis CACHE PATH "")
 gen_default_lib_search_dirs(vorbis)
 
 if(WIN32)

--- a/Source/CMake/Properties.cmake
+++ b/Source/CMake/Properties.cmake
@@ -192,5 +192,5 @@ endif()
 set(BS_DEPENDENCY_DIR "${PROJECT_BINARY_DIR}/Dependencies" CACHE STRING "The output location of dependencies.")
 mark_as_advanced(BS_DEPENDENCY_DIR)
 
-set(BS_ASSET_DIR "${PROJECT_BINARY_DIR}/Data" CACHE STRING "The output location of builtin assets.")
+set(BS_ASSET_DIR "${PROJECT_SOURCE_DIR}/Data" CACHE STRING "The output location of builtin assets. Do not change unless you really know what you're doing.")
 mark_as_advanced(BS_ASSET_DIR)

--- a/Source/CMake/Properties.cmake
+++ b/Source/CMake/Properties.cmake
@@ -187,3 +187,10 @@ if (UNIX)
 
 	endif()
 endif()
+
+# Custom Dependency Directory
+set(BS_DEPENDENCY_DIR "${PROJECT_BINARY_DIR}/Dependencies" CACHE STRING "The output location of dependencies.")
+mark_as_advanced(BS_DEPENDENCY_DIR)
+
+set(BS_ASSET_DIR "${PROJECT_BINARY_DIR}/Data" CACHE STRING "The output location of builtin assets.")
+mark_as_advanced(BS_ASSET_DIR)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 # Ensure dependencies are up to date
 ## Check prebuilt dependencies that are downloaded in a .zip
-check_and_update_binary_deps(bsf ${BSF_SOURCE_DIR}/../Dependencies/ ${BS_FRAMEWORK_PREBUILT_DEPENDENCIES_VERSION})
+check_and_update_binary_deps(bsf ${BS_DEPENDENCY_DIR} ${BS_FRAMEWORK_PREBUILT_DEPENDENCIES_VERSION})
 
 ## Check dependencies built from source
 if(WIN32)
@@ -63,7 +63,7 @@ if(WIN32)
 endif()
 
 ## Check data dependencies
-check_and_update_builtin_assets(bsf ${BSF_SOURCE_DIR}/../Data ${BS_FRAMEWORK_BUILTIN_ASSETS_VERSION} YES)
+check_and_update_builtin_assets(bsf ${BS_ASSET_DIR} ${BS_FRAMEWORK_BUILTIN_ASSETS_VERSION} YES)
 
 # Config file
 ## Note: Must happen before script binding generation
@@ -86,8 +86,8 @@ set(RENDERER_MODULE_LIB bsfRenderBeast)
 set(PHYSICS_MODULE_LIB bsfPhysX)
 
 ## Generate config files)
-configure_file("${BSF_SOURCE_DIR}/CMake/BsEngineConfig.h.in" "${BSF_SOURCE_DIR}/Foundation/bsfEngine/BsEngineConfig.h")
-configure_file("${BSF_SOURCE_DIR}/CMake/BsFrameworkConfig.h.in" "${BSF_SOURCE_DIR}/Foundation/bsfUtility/BsFrameworkConfig.h")
+configure_file("${BSF_SOURCE_DIR}/CMake/BsEngineConfig.h.in" "${PROJECT_BINARY_DIR}/GeneratedCode/Foundation/bsfEngine/BsEngineConfig.h")
+configure_file("${BSF_SOURCE_DIR}/CMake/BsFrameworkConfig.h.in" "${PROJECT_BINARY_DIR}/GeneratedCode/Foundation/bsfUtility/BsFrameworkConfig.h")
 
 # Set files disallowed in precompiled headers
 set_directory_properties(PROPERTIES

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -43,6 +43,12 @@ endif()
 # Ensure dependencies are up to date
 ## Check prebuilt dependencies that are downloaded in a .zip
 check_and_update_binary_deps(bsf ${BS_DEPENDENCY_DIR} ${BS_FRAMEWORK_PREBUILT_DEPENDENCIES_VERSION})
+if (BS_TOP_LEVEL)
+	bsf_dependency_binary_copy(Debug "${BS_BINARY_OUTPUT_DIR}/Debug")
+	bsf_dependency_binary_copy(RelWithDebInfo "${BS_BINARY_OUTPUT_DIR}/RelWithDebInfo")
+	bsf_dependency_binary_copy(MinSizeRel "${BS_BINARY_OUTPUT_DIR}/MinSizeRel")
+	bsf_dependency_binary_copy(Release "${BS_BINARY_OUTPUT_DIR}/Release")
+endif()
 
 ## Check dependencies built from source
 if(WIN32)

--- a/Source/Foundation/CMakeLists.txt
+++ b/Source/Foundation/CMakeLists.txt
@@ -36,9 +36,12 @@ add_library(bsf SHARED ${BS_UTILITY_SRC} ${BS_CORE_SRC} ${BS_ENGINE_SRC})
 
 # Includes
 target_include_directories(bsf PUBLIC "bsfUtility" "bsfCore" "bsfEngine")
+target_include_directories(bsf PUBLIC "${PROJECT_BINARY_DIR}/GeneratedCode/Foundation/bsfEngine/"
+	                                  "${PROJECT_BINARY_DIR}/GeneratedCode/Foundation/bsfUtility/"
+	)
 
 # Defines
-target_compile_definitions(bsf PRIVATE 
+target_compile_definitions(bsf PRIVATE
 	-DBS_EXPORTS
 	-DBS_CORE_EXPORTS
 	-DBS_UTILITY_EXPORTS
@@ -49,7 +52,7 @@ target_compile_definitions(bsf PRIVATE
 
 # Libraries
 ## External lib: NVTT
-target_link_libraries(bsf PRIVATE ${nvtt_LIBRARIES})	
+target_link_libraries(bsf PRIVATE ${nvtt_LIBRARIES})
 
 ## External lib: Snappy
 target_link_libraries(bsf PRIVATE ${snappy_LIBRARIES})
@@ -89,7 +92,7 @@ set_property(TARGET bsf PROPERTY FOLDER Foundation)
 install(
 	DIRECTORY bsfUtility
 	DESTINATION include
-	FILES_MATCHING 
+	FILES_MATCHING
 	PATTERN "*.h"
 	PATTERN "*.hpp"
 	PATTERN "Private" EXCLUDE


### PR DESCRIPTION
## Preface

Note this PR isn't currently intended as a complete implementation ready for merge, but as a way to start discussion about the issues it's trying to solve as well as the code itself. This hasn't been tested nearly enough on any platform, or in any kind of other scenario.

## What

Pulling all the downloading and configured dependencies into the build folder as opposed to the source folder.

## Rationale

1. I have encountered scenarios where there are multiple builds for multiple platforms pulling form the same source directory (shared dir between a windows host and linux vm) causing conflicts in the dependency resolution.
2. CLion initializes all builds at the same time by calling CMake concurrently. Because of the inherent race condition with downloading and extracting the dependency and asset files, the first couple times I try to reload the project it fails, until something finally wins the fight and things can continue on as normal.
3. To me, it seems like good policy that nothing should change in the source tree as a result of a build happening. This allows many different builds to happen simultaneously with the advantage that if a build directory gets deleted, **everything** gets deleted, and it's as if you just cloned the repository

## Comments

I know for sure I am missing parts, and I haven't done full testing yet in a variety of scenarios, but can you point me in the direction of anything else I may be missing. Breaking the fixed location paradigm within the cmake code is hard as it's hard to tell what everything touches.