### PR TITLE
Bugfix: glMemoryBarrier() after draw/compute calls

### DIFF
--- a/Source/Plugins/bsfGLRenderAPI/BsGLRenderAPI.cpp
+++ b/Source/Plugins/bsfGLRenderAPI/BsGLRenderAPI.cpp
@@ -2155,7 +2155,9 @@ namespace bs { namespace ct
 		if(!mDrawCallInProgress)
 			return;
 
+#if BS_OPENGL_4_2 || BS_OPENGLES_3_1
 		glMemoryBarrier(GL_ALL_BARRIER_BITS);
+#endif
 
 		mDrawCallInProgress = false;
 	}

--- a/Source/Plugins/bsfGLRenderAPI/BsGLRenderAPI.cpp
+++ b/Source/Plugins/bsfGLRenderAPI/BsGLRenderAPI.cpp
@@ -1269,6 +1269,8 @@ namespace bs { namespace ct
 
 			glDispatchCompute(numGroupsX, numGroupsY, numGroupsZ);
 			BS_CHECK_GL_ERROR();
+
+			glMemoryBarrier(GL_ALL_BARRIER_BITS);
 #else
 			LOGWRN("Compute shaders not supported on current OpenGL version.");
 #endif
@@ -2152,6 +2154,8 @@ namespace bs { namespace ct
 	{
 		if(!mDrawCallInProgress)
 			return;
+
+		glMemoryBarrier(GL_ALL_BARRIER_BITS);
 
 		mDrawCallInProgress = false;
 	}


### PR DESCRIPTION
Here's the first PR I promised. I hope I didn't miss any required glMemoryBarrier() spots.