### PR TITLE
Feature: Add ConvexVolume::getPlane(FrustumPlane)

### DIFF
--- a/Source/Foundation/bsfUtility/Math/BsConvexVolume.cpp
+++ b/Source/Foundation/bsfUtility/Math/BsConvexVolume.cpp
@@ -5,6 +5,7 @@
 #include "Math/BsSphere.h"
 #include "Math/BsPlane.h"
 #include "Math/BsMath.h"
+#include "Error/BsException.h"
 
 namespace bs
 {
@@ -62,6 +63,17 @@ namespace bs
 			mPlanes.push_back(plane);
 		}
 
+		// Far
+		{
+			Plane plane;
+			plane.normal.x = proj[3][0] - proj[2][0];
+			plane.normal.y = proj[3][1] - proj[2][1];
+			plane.normal.z = proj[3][2] - proj[2][2];
+			plane.d = proj[3][3] - proj[2][3];
+
+			mPlanes.push_back(plane);
+		}
+
 		// Near
 		if(useNearPlane)
 		{
@@ -70,17 +82,6 @@ namespace bs
 			plane.normal.y = proj[3][1] + proj[2][1];
 			plane.normal.z = proj[3][2] + proj[2][2];
 			plane.d = proj[3][3] + proj[2][3];
-
-			mPlanes.push_back(plane);
-		}
-
-		// Far
-		{
-			Plane plane;
-			plane.normal.x = proj[3][0] - proj[2][0];
-			plane.normal.y = proj[3][1] - proj[2][1];
-			plane.normal.z = proj[3][2] - proj[2][2];
-			plane.d = proj[3][3] - proj[2][3];
 
 			mPlanes.push_back(plane);
 		}
@@ -138,5 +139,15 @@ namespace bs
 		}
 
 		return true;
+	}
+
+	const Plane& ConvexVolume::getPlane(FrustumPlane whichPlane) const
+	{
+		if(whichPlane >= mPlanes.size())
+		{
+			BS_EXCEPT(InvalidParametersException, "Requested plane does not exist in this volume.");
+		}
+
+		return mPlanes[whichPlane];
 	}
 }

--- a/Source/Foundation/bsfUtility/Math/BsConvexVolume.h
+++ b/Source/Foundation/bsfUtility/Math/BsConvexVolume.h
@@ -14,12 +14,12 @@ namespace bs
 	/**	Clip planes that form the camera frustum (visible area). */
 	enum FrustumPlane
 	{
-		FRUSTUM_PLANE_NEAR = 0,
-		FRUSTUM_PLANE_FAR = 1,
-		FRUSTUM_PLANE_LEFT = 2,
-		FRUSTUM_PLANE_RIGHT = 3,
-		FRUSTUM_PLANE_TOP = 4,
-		FRUSTUM_PLANE_BOTTOM = 5
+		FRUSTUM_PLANE_LEFT = 0,
+		FRUSTUM_PLANE_RIGHT = 1,
+		FRUSTUM_PLANE_TOP = 2,
+		FRUSTUM_PLANE_BOTTOM = 3,
+		FRUSTUM_PLANE_FAR = 4,
+		FRUSTUM_PLANE_NEAR = 5
 	};
 
 	/** Represents a convex volume defined by planes representing the volume border. */
@@ -55,6 +55,9 @@ namespace bs
 
 		/** Returns the internal set of planes that represent the volume. */
 		Vector<Plane> getPlanes() const { return mPlanes; }
+
+		/** Returns the specified plane that represents the volume. */
+		const Plane& getPlane(FrustumPlane whichPlane) const;
 
 	private:
 		Vector<Plane> mPlanes;


### PR DESCRIPTION
And here's the second PR I promised. I thought about dropping the bounds check and defining the method as a one-liner in the header file for performance, but maybe it's not obvious when the near plane is not there so that could lead to strange bugs when requesting the near plane. Let me know if you prefer that other approach with a one-liner method in the header file, I'm fine with both. :-)