### PR TITLE
Basic fixes for 3 kinds of compiler warnings

### DIFF
--- a/Source/Foundation/bsfCore/Scene/BsSceneManager.h
+++ b/Source/Foundation/bsfCore/Scene/BsSceneManager.h
@@ -213,7 +213,7 @@ namespace bs
 		Vector<HComponent> mUninitializedComponents;
 
 		std::array<Vector<HComponent>*, 3> mComponentsPerState = 
-			{ &mActiveComponents, &mInactiveComponents, &mUninitializedComponents };
+			{ { &mActiveComponents, &mInactiveComponents, &mUninitializedComponents } };
 
 		SPtr<RenderTarget> mMainRT;
 		HEvent mMainRTResizedConn;

--- a/Source/Foundation/bsfEngine/Utility/BsShapeMeshes3D.cpp
+++ b/Source/Foundation/bsfEngine/Utility/BsShapeMeshes3D.cpp
@@ -1202,7 +1202,7 @@ namespace bs
 			{
 				int offsetA = i == 0 ? numArcVertices - 1 : i - 1;
 				int offsetB = i;
-				int offsetC = i == numArcVertices ? 1 : i + 1;
+				int offsetC = i == (INT32)numArcVertices ? 1 : i + 1;
 
 				Vector3* a = (Vector3*)(outVertices + (offsetA * vertexStride));
 				Vector3* b = (Vector3*)(outVertices + (offsetB * vertexStride));

--- a/Source/Plugins/bsfGLRenderAPI/BsGLUtil.h
+++ b/Source/Plugins/bsfGLRenderAPI/BsGLUtil.h
@@ -45,7 +45,7 @@ namespace bs { namespace ct
 
 #include "MacOS/BsMacOSGLSupport.h"
 
-namespace bs::ct
+namespace bs { namespace ct
 {
 	/** @addtogroup GL
 	 *  @{
@@ -58,5 +58,5 @@ namespace bs::ct
 	}
 
 	/** @} */
-}
+}}
 #endif

--- a/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSContext.h
+++ b/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSContext.h
@@ -5,7 +5,7 @@
 #include "BsGLPrerequisites.h"
 #include "BsGLContext.h"
 
-namespace bs::ct
+namespace bs { namespace ct
 {
 	/** @addtogroup GL
 	 *  @{
@@ -60,5 +60,5 @@ namespace bs::ct
 	};
 
 	/** @} */
-}
+}}
 

--- a/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSContext.mm
+++ b/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSContext.mm
@@ -7,7 +7,7 @@
 #include "Private/MacOS/BsMacOSPlatform.h"
 #import <AppKit/AppKit.h>
 
-namespace bs::ct
+namespace bs { namespace ct
 {
 	struct MacOSContext::Pimpl
 	{
@@ -137,5 +137,5 @@ namespace bs::ct
 	{
 		CGLUnlockContext(m->context.CGLContextObj);
 	}
-}
+}}
 

--- a/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSGLSupport.cpp
+++ b/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSGLSupport.cpp
@@ -7,7 +7,7 @@
 #include "BsGLRenderAPI.h"
 #include <dlfcn.h>
 
-namespace bs::ct
+namespace bs { namespace ct
 {
 	SPtr<bs::RenderWindow> MacOSGLSupport::newWindow(
 		RENDER_WINDOW_DESC& desc,
@@ -59,5 +59,5 @@ namespace bs::ct
 	{
 		return bs_shared_ptr_new<MacOSVideoModeInfo>();
 	}
-}
+}}
 

--- a/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSGLSupport.h
+++ b/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSGLSupport.h
@@ -6,7 +6,7 @@
 #include "BsGLSupport.h"
 #include "BsGLRenderAPI.h"
 
-namespace bs::ct
+namespace bs { namespace ct
 {
 	class MacOSContext;
 
@@ -38,5 +38,5 @@ namespace bs::ct
 	};
 
 	/** @} */
-}
+}}
 

--- a/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSVideoModeInfo.cpp
+++ b/Source/Plugins/bsfGLRenderAPI/MacOS/BsMacOSVideoModeInfo.cpp
@@ -3,7 +3,7 @@
 #include "MacOS/BsMacOSVideoModeInfo.h"
 #include <IOKit/graphics/IOGraphicsLib.h>
 
-namespace bs::ct
+namespace bs { namespace ct
 {
 	MacOSVideoModeInfo::MacOSVideoModeInfo()
 	{
@@ -123,5 +123,5 @@ namespace bs::ct
 		if(!mIsCustom && mModeRef)
 			CGDisplayModeRelease(mModeRef);
 	}
-}
+}}
 


### PR DESCRIPTION
Just some simple fixes for compiler warnings I came across (using clang on Xcode 9.2):

- [Suggest braces around initialization of subobject](https://github.com/GameFoundry/bsf/commit/6ba17be300ab0ebe81f5350019b2cb5c53aa7b7e)
- [Nested namespace definition is a C++1z extension; define each namespace separately](https://github.com/GameFoundry/bsf/commit/c23d34486b55d6e8cd759bfe9fff657fe4a8043d)
- [Comparison of integers of different signs: 'INT32' (aka 'int') and 'UINT32' (aka 'unsigned int')](https://github.com/GameFoundry/bsf/commit/2b8f6718b652b434c381c2112c528b3ed45ad992)
    - Not entirely sure about this exact fix. Might just want to change the type of `i` to `UINT32`, but that might have implications about conversions to `int` for the offset values. Don't know if we care about that at all?