### PR TITLE
Add epsilon to point on plain side calculation

### DIFF
--- a/Source/Foundation/bsfUtility/Math/BsPlane.cpp
+++ b/Source/Foundation/bsfUtility/Math/BsPlane.cpp
@@ -35,15 +35,15 @@ namespace bs
 		return normal.dot(point) - d;
 	}
 
-	Plane::Side Plane::getSide(const Vector3& point) const
+	Plane::Side Plane::getSide(const Vector3& point, const float epsilon) const
 	{
 		float dist = getDistance(point);
 
-		if (dist < 0.0f)
-			return Plane::NEGATIVE_SIDE;
-
-		if (dist > 0.0f)
+		if (dist > epsilon)
 			return Plane::POSITIVE_SIDE;
+
+		if (dist < -epsilon)
+			return Plane::NEGATIVE_SIDE;
 
 		return Plane::NO_SIDE;
 	}

--- a/Source/Foundation/bsfUtility/Math/BsPlane.h
+++ b/Source/Foundation/bsfUtility/Math/BsPlane.h
@@ -42,7 +42,7 @@ namespace bs
 		 * 			
 		 * @note	NO_SIDE signifies the point is on the plane.
 		 */
-		Side getSide(const Vector3& point) const;
+		Side getSide(const Vector3& point, const float epsilon = 0.0f) const;
 
 		/**
 		 * Returns the side where the alignedBox is. The flag BOTH_SIDE indicates an intersecting box.


### PR DESCRIPTION
Adds epsilon value when calculating Plane.getSide(point).  This is useful when floating point precision makes it near impossible to correctly identify when a point is on the plain.   For example, binary space partition tree calculation.