### PR TITLE
Generate mPointerDelta and event.delta before event is fired

### DIFF
--- a/Source/Foundation/bsfCore/Input/BsInput.cpp
+++ b/Source/Foundation/bsfCore/Input/BsInput.cpp
@@ -185,10 +185,12 @@ namespace bs
 			event.type = PointerEventType::CursorMoved;
 			event.screenPos = pointerPos;
 
-			onPointerMoved(event);
-
 			if (mLastPositionSet)
 				mPointerDelta = event.screenPos - mLastPointerPosition;
+
+			event.delta = mPointerDelta;
+
+			onPointerMoved(event);
 
 			mLastPointerPosition = event.screenPos;
 			mLastPositionSet = true;


### PR DESCRIPTION
The delta information in the event onPointerMoved was 0 for the x and y coordinates, so I moved the generation of the delta coordinates before the event is fired.