### PR TITLE
BsCCapsuleCollider calculate local rotation from normal on construction

### DIFF
--- a/Source/Foundation/bsfCore/Components/BsCCapsuleCollider.cpp
+++ b/Source/Foundation/bsfCore/Components/BsCCapsuleCollider.cpp
@@ -7,15 +7,25 @@
 
 namespace bs
 {
+	Quaternion _calculateRotationFromNormal(Vector3 normal)
+	{
+		normal.normalize();
+		return Quaternion::getRotationFromTo(Vector3::UNIT_X, normal);
+	}
+
 	CCapsuleCollider::CCapsuleCollider()
 	{
 		setName("CapsuleCollider");
+
+		mLocalRotation = _calculateRotationFromNormal(mNormal);
 	}
 
 	CCapsuleCollider::CCapsuleCollider(const HSceneObject& parent, float radius, float halfHeight)
 		: CCollider(parent), mRadius(radius), mHalfHeight(halfHeight)
 	{
 		setName("CapsuleCollider");
+
+		mLocalRotation = _calculateRotationFromNormal(mNormal);
 	}
 
 	void CCapsuleCollider::setNormal(const Vector3& normal)
@@ -24,9 +34,7 @@ namespace bs
 			return;
 
 		mNormal = normal;
-		mNormal.normalize();
-
-		mLocalRotation = Quaternion::getRotationFromTo(Vector3::UNIT_X, normal);
+		mLocalRotation = _calculateRotationFromNormal(mNormal);
 
 		if (mInternal != nullptr)
 			updateTransform();

--- a/Source/Foundation/bsfCore/Components/BsCCapsuleCollider.cpp
+++ b/Source/Foundation/bsfCore/Components/BsCCapsuleCollider.cpp
@@ -7,17 +7,11 @@
 
 namespace bs
 {
-	Quaternion _calculateRotationFromNormal(Vector3 normal)
-	{
-		normal.normalize();
-		return Quaternion::getRotationFromTo(Vector3::UNIT_X, normal);
-	}
-
 	CCapsuleCollider::CCapsuleCollider()
 	{
 		setName("CapsuleCollider");
 
-		mLocalRotation = _calculateRotationFromNormal(mNormal);
+		mLocalRotation = Quaternion::getRotationFromTo(Vector3::UNIT_X, mNormal);
 	}
 
 	CCapsuleCollider::CCapsuleCollider(const HSceneObject& parent, float radius, float halfHeight)
@@ -25,7 +19,7 @@ namespace bs
 	{
 		setName("CapsuleCollider");
 
-		mLocalRotation = _calculateRotationFromNormal(mNormal);
+		mLocalRotation = Quaternion::getRotationFromTo(Vector3::UNIT_X, mNormal);
 	}
 
 	void CCapsuleCollider::setNormal(const Vector3& normal)
@@ -33,8 +27,8 @@ namespace bs
 		if (mNormal == normal)
 			return;
 
-		mNormal = normal;
-		mLocalRotation = _calculateRotationFromNormal(mNormal);
+		mNormal = bs::Vector3::normalize(normal);
+		mLocalRotation = Quaternion::getRotationFromTo(Vector3::UNIT_X, mNormal);
 
 		if (mInternal != nullptr)
 			updateTransform();


### PR DESCRIPTION
There is currently an inconsistency when creating a BsCCapsuleCollider and setting its normal property. The default value for the normal property is `bs::Vector3::VECTOR_Y` but the initial rotation of the base bs::CCollider use the Quaternation of `bs::Vector3::VECTOR_X`. That's the reason why the Collider will be orientated in the wrong direction.
Additionally the current code checks in the setNormal function if the new normal differs from the current one, thus we can't change the normal `bs::Vector3::VECTOR_Y` to bypass this issue. The only solution is to first set it to `bs::Vector3::VECTOR_X` or `bs::Vector3::VECTOR_Z` and then reset it to `bs::Vector3::VECTOR_Y`. This commit fixes this bug.


