### PR TITLE
Docs: Fix BSL-shader sample

### DIFF
--- a/Documentation/Manuals/User/bsl.md
+++ b/Documentation/Manuals/User/bsl.md
@@ -37,7 +37,7 @@ shader MyShader
 
 		float4 fsmain(in VStoFS input) : SV_Target0
 		{
-			return float4(1.0f, 1.0f, 1.0f 1.0f); 
+			return float4(1.0f, 1.0f, 1.0f, 1.0f); 
 		}	
 	};
 };


### PR DESCRIPTION
There was a missing comma, so it wouldn't compile after a straight copy&paste.