### PR TITLE
Misc build fixes for MSVC Ninja build

### DIFF
--- a/Source/CMake/HelperMethods.cmake
+++ b/Source/CMake/HelperMethods.cmake
@@ -109,14 +109,8 @@ MACRO(add_imported_library LIB_NAME RELEASE_NAME DEBUG_NAME IS_SHARED)
 		add_library(${LIB_NAME} STATIC IMPORTED)
 	endif()
 
-	if(CMAKE_CONFIGURATION_TYPES) # Multiconfig generator?
-		set_target_properties(${LIB_NAME} PROPERTIES IMPORTED_LOCATION_DEBUG "${DEBUG_NAME}")
-		set_target_properties(${LIB_NAME} PROPERTIES IMPORTED_LOCATION_RELWITHDEBINFO "${RELEASE_NAME}")
-		set_target_properties(${LIB_NAME} PROPERTIES IMPORTED_LOCATION_MINSIZEREL "${RELEASE_NAME}")
-		set_target_properties(${LIB_NAME} PROPERTIES IMPORTED_LOCATION_RELEASE "${RELEASE_NAME}")
-	else()
-		set_target_properties(${LIB_NAME} PROPERTIES IMPORTED_LOCATION "${RELEASE_NAME}")
-	endif()
+	set_target_properties(${LIB_NAME} PROPERTIES IMPORTED_LOCATION "${RELEASE_NAME}")
+	set_target_properties(${LIB_NAME} PROPERTIES IMPORTED_LOCATION_DEBUG "${DEBUG_NAME}")
 ENDMACRO()
 
 MACRO(find_imported_library3 FOLDER_NAME LIB_NAME DEBUG_LIB_NAME IS_SHARED)
@@ -553,7 +547,7 @@ function(add_common_flags target)
 			set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:Debug>:/Zi>)
 		endif()
 
-		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:RelWithDebInfo>:/GL /Gy /Zi /O2 /Oi /MD -DDEBUG>)
+		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:RelWithDebInfo>:/GL /Gy /Zi /O2 /Oi /MD -DNDEBUG>)
 		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:MinSizeRel>:/GL /Gy /Zi /O2 /Oi /MD -DNDEBUG>)
 		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:Release>:/GL /Gy /Zi /O2 /Oi /MD -DNDEBUG>)
 
@@ -574,7 +568,7 @@ function(add_common_flags target)
 		endif()
 
 		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:Debug>:-ggdb -O0 -DDEBUG>)
-		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:RelWithDebInfo>:-ggdb -O2 -DDEBUG -Wno-unused-variable>)
+		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:RelWithDebInfo>:-ggdb -O2 -DNDEBUG -Wno-unused-variable>)
 		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:MinSizeRel>:-ggdb -O2 -DNDEBUG -Wno-unused-variable>)
 		set_property(TARGET ${target} APPEND PROPERTY COMPILE_OPTIONS $<$<CONFIG:Release>:-ggdb -O2 -DNDEBUG -Wno-unused-variable>)
 

--- a/Source/Foundation/bsfCore/Animation/BsAnimationClip.cpp
+++ b/Source/Foundation/bsfCore/Animation/BsAnimationClip.cpp
@@ -183,7 +183,7 @@ namespace bs
 				auto iterFind = mNameMapping.find(entry.name);
 				if (iterFind == mNameMapping.end())
 				{
-					UINT32* indices = mNameMapping[entry.name];
+					UINT32* indices = mNameMapping[entry.name].data();
 					memset(indices, -1, sizeof(UINT32) * (int)CurveType::Count);
 
 					indices[typeIdx] = i;
@@ -215,7 +215,7 @@ namespace bs
 				auto iterFind = mNameMapping.find(entry.name);
 				if (iterFind == mNameMapping.end())
 				{
-					UINT32* indices = mNameMapping[entry.name];
+					UINT32* indices = mNameMapping[entry.name].data();
 					memset(indices, -1, sizeof(UINT32) * (int)CurveType::Count);
 
 					indices[typeIdx] = i;
@@ -249,7 +249,7 @@ namespace bs
 		auto iterFind = mNameMapping.find(name);
 		if (iterFind != mNameMapping.end())
 		{
-			const UINT32* indices = iterFind->second;
+			const UINT32* indices = iterFind->second.data();
 
 			mapping.position = indices[(UINT32)CurveType::Position];
 			mapping.rotation = indices[(UINT32)CurveType::Rotation];
@@ -264,7 +264,7 @@ namespace bs
 		auto iterFind = mNameMapping.find(name);
 		if (iterFind != mNameMapping.end())
 		{
-			const UINT32* indices = iterFind->second;
+			const UINT32* indices = iterFind->second.data();
 
 			frameIdx = indices[(UINT32)CurveType::MorphFrame];
 			weightIdx = indices[(UINT32)CurveType::MorphWeight];

--- a/Source/Foundation/bsfCore/Animation/BsAnimationClip.h
+++ b/Source/Foundation/bsfCore/Animation/BsAnimationClip.h
@@ -7,6 +7,7 @@
 #include "Math/BsVector3.h"
 #include "Math/BsQuaternion.h"
 #include "Animation/BsAnimationCurve.h"
+#include <array>
 
 namespace bs
 {
@@ -306,7 +307,7 @@ namespace bs
 		/** 
 		 * Contains a map from curve name to curve index. Indices are stored as specified in CurveType enum. 
 		 */
-		UnorderedMap<String, UINT32[(int)CurveType::Count]> mNameMapping;
+		UnorderedMap<String, std::array<UINT32, (int)CurveType::Count>> mNameMapping;
 
 		Vector<AnimationEvent> mEvents;
 		bool mIsAdditive;

--- a/Source/Scripting/bsfMono/CMakeLists.txt
+++ b/Source/Scripting/bsfMono/CMakeLists.txt
@@ -34,6 +34,8 @@ if(BS_IS_BANSHEE3D)
 	# Target for running generic Mono code
 	add_executable(MonoExec BsMonoExec.cpp)
 	target_link_libraries(MonoExec ${mono_LIBRARIES})
+
+	install_bsf_target(MonoExec)
 endif()
 
 # IDE specific


### PR DESCRIPTION
By default 'Open Folder' in MSVC uses the Ninja generator, this fixes some issues when it attempts to run and simplifies some code

The other notable change in here is changing RelWithDebInfo to use -DNDEBUG not -DDEBUG to match the default CMake environment, this also fixes issues where the C# Assembly loading is expecting to use the Debug path when using RelWithDebInfo.