### PR TITLE
Provide unmapped triangle index for mesh raycast queries

### DIFF
--- a/Source/Foundation/bsfCore/Physics/BsPhysicsCommon.h
+++ b/Source/Foundation/bsfCore/Physics/BsPhysicsCommon.h
@@ -77,6 +77,13 @@ namespace bs
 		float distance = 0.0f; /**< Distance from the query origin to the hit position. */
 		UINT32 triangleIdx = 0; /**< Index of the triangle that was hit (only applicable when triangle meshes are hit). */
 
+		/**
+		 * Unmapped index of the triangle that was hit (only applicable when triangle meshes are hit). 
+		 * It represents an index into the original MeshData used to create the BsPhysicsMesh associated with #collider.
+		 * In contrast, #triangleIdx is only a valid index for the MeshData directly obtained from #collider which can differ from the original MeshData due to the internal implementation.
+		 */
+		UINT32 unmappedTriangleIdx = 0;
+
 		/** 
 		 * Component of the collider that was hit. This may be null if the hit collider has no owner component, in which
 		 * case refer to #colliderRaw.

--- a/Source/Plugins/bsfPhysX/BsPhysX.cpp
+++ b/Source/Plugins/bsfPhysX/BsPhysX.cpp
@@ -352,16 +352,18 @@ namespace bs
 		return PxFilterFlags();
 	}
 
-	void setUnmappedTriangleIndex(const PxQueryHit& input, PhysicsQueryHit& output)
+	void setUnmappedTriangleIndex(const PxQueryHit& input, PhysicsQueryHit& output, PxShape* shapeHint = nullptr)
 	{
 		// We can only assign a valid unmapped triangle index if the hit geometry is a triangle mesh
 		// and it was created with the flags to store the remapping.
 		// As a fallback, the raw face index is used.
 
-		if (input.shape != nullptr && input.shape->getGeometryType() == PxGeometryType::eTRIANGLEMESH)
+		PxShape* shape = shapeHint ? shapeHint : input.shape;
+
+		if (shape != nullptr && shape->getGeometryType() == PxGeometryType::eTRIANGLEMESH)
 		{
 			PxTriangleMeshGeometry triMeshGeometry;
-			input.shape->getTriangleMeshGeometry(triMeshGeometry);
+			shape->getTriangleMeshGeometry(triMeshGeometry);
 
 			if (triMeshGeometry.isValid() && triMeshGeometry.triangleMesh->getTrianglesRemap() != nullptr)
 			{
@@ -373,13 +375,13 @@ namespace bs
 		output.unmappedTriangleIdx = input.faceIndex;
 	}
 
-	void parseHit(const PxRaycastHit& input, PhysicsQueryHit& output)
+	void parseHit(const PxRaycastHit& input, PhysicsQueryHit& output, PxShape* shapeHint = nullptr)
 	{
 		output.point = fromPxVector(input.position);
 		output.normal = fromPxVector(input.normal);
 		output.distance = input.distance;
 		output.triangleIdx = input.faceIndex;
-		setUnmappedTriangleIndex(input, output);
+		setUnmappedTriangleIndex(input, output, shapeHint);
 		output.uv = Vector2(input.u, input.v);
 
 		if(input.shape)
@@ -393,14 +395,14 @@ namespace bs
 		}
 	}
 
-	void parseHit(const PxSweepHit& input, PhysicsQueryHit& output)
+	void parseHit(const PxSweepHit& input, PhysicsQueryHit& output, PxShape* shapeHint = nullptr)
 	{
 		output.point = fromPxVector(input.position);
 		output.normal = fromPxVector(input.normal);
 		output.uv = Vector2::ZERO;
 		output.distance = input.distance;
 		output.triangleIdx = input.faceIndex;
-		setUnmappedTriangleIndex(input, output);
+		setUnmappedTriangleIndex(input, output, shapeHint);
 		output.colliderRaw = (Collider*)input.shape->userData;
 
 		if (output.colliderRaw != nullptr)
@@ -744,7 +746,7 @@ namespace bs
 			maxDist, hitFlags, maxHits, &hitInfo, anyHit);
 
 		if(hitCount > 0)
-			parseHit(hitInfo, hit);
+			parseHit(hitInfo, hit, shape);
 
 		return hitCount > 0;
 	}

--- a/Source/Plugins/bsfPhysX/BsPhysX.cpp
+++ b/Source/Plugins/bsfPhysX/BsPhysX.cpp
@@ -746,7 +746,7 @@ namespace bs
 			maxDist, hitFlags, maxHits, &hitInfo, anyHit);
 
 		if(hitCount > 0)
-			parseHit(hitInfo, hit, shape);
+			parseHit(hitInfo, hit, shape); // We have to provide a hint for the tested shape, as it is not contained in single-geometry raycast hit results
 
 		return hitCount > 0;
 	}


### PR DESCRIPTION
This PR adds the member `PhysicsQueryHit::unmappedTriangleIndex` which allows using the result of a raycast query to index faces in the original mesh and not only in the physics mesh associated with a mesh collider. It is useful for cases where arbitrary vertex semantics are to be evaluated (e. g. vertex color) which are not accessible through the physics mesh (as it only contains spatial vertex information).