### PR TITLE
Use struct as deleter for smart pointers by default

### DIFF
--- a/Source/Foundation/bsfUtility/Allocators/BsMemoryAllocator.h
+++ b/Source/Foundation/bsfUtility/Allocators/BsMemoryAllocator.h
@@ -269,6 +269,22 @@ namespace bs
 		MemoryAllocator<Alloc>::free(ptr);
 	}
 
+	/** Callable struct that acts as a proxy for bs_delete */
+	template<class T, class Alloc = GenAlloc>
+	struct Deleter
+	{
+		constexpr Deleter() noexcept = default;
+
+		/** Constructor enabling deleter conversion and therefore polymorphism with smart points (if they use the same allocator). */
+		template <class T2, std::enable_if_t<std::is_convertible_v<T2*, T*>, int> = 0>
+		constexpr Deleter(const Deleter<T2, Alloc>& other) noexcept { }
+
+		inline void operator()(T* ptr) const
+		{
+			bs_delete<T, Alloc>(ptr);
+		}
+	};
+
 	/** Destructs and frees the specified array of objects. */
 	template<class T, class Alloc = GenAlloc>
 	inline void bs_deleteN(T* ptr, size_t count)

--- a/Source/Foundation/bsfUtility/Allocators/BsMemoryAllocator.h
+++ b/Source/Foundation/bsfUtility/Allocators/BsMemoryAllocator.h
@@ -276,7 +276,7 @@ namespace bs
 		constexpr Deleter() noexcept = default;
 
 		/** Constructor enabling deleter conversion and therefore polymorphism with smart points (if they use the same allocator). */
-		template <class T2, std::enable_if_t<std::is_convertible_v<T2*, T*>, int> = 0>
+		template <class T2, std::enable_if_t<std::is_convertible<T2*, T*>::value, int> = 0>
 		constexpr Deleter(const Deleter<T2, Alloc>& other) noexcept { }
 
 		inline void operator()(T* ptr) const

--- a/Source/Foundation/bsfUtility/Prerequisites/BsStdHeaders.h
+++ b/Source/Foundation/bsfUtility/Prerequisites/BsStdHeaders.h
@@ -193,7 +193,7 @@ namespace bs
 	 * Smart pointer that retains shared ownership of an project through a pointer. Reference to the object must be unique.
 	 * The object is destroyed automatically when the pointer to the object is destroyed.
 	 */
-	template <typename T, typename Alloc = GenAlloc, typename Delete = decltype(&bs_delete<T, Alloc>)>
+	template <typename T, typename Alloc = GenAlloc, typename Delete = Deleter<T, Alloc>>
 	using UPtr = std::unique_ptr<T, Delete>;
 
 	/** Create a new shared pointer using a custom allocator category. */
@@ -207,8 +207,8 @@ namespace bs
 	 * Create a new shared pointer from a previously constructed object.
 	 * Pointer specific data will be allocated using the provided allocator category.
 	 */
-	template<typename Type, typename MainAlloc = GenAlloc, typename PtrDataAlloc = GenAlloc, typename Deleter = decltype(&bs_delete<Type, MainAlloc>)>
-	SPtr<Type> bs_shared_ptr(Type* data, Deleter del = &bs_delete<Type, MainAlloc>)
+	template<typename Type, typename MainAlloc = GenAlloc, typename PtrDataAlloc = GenAlloc, typename Delete = Deleter<Type, MainAlloc>>
+	SPtr<Type> bs_shared_ptr(Type* data, Delete del = Delete())
 	{
 		return SPtr<Type>(data, std::move(del), StdAlloc<Type, PtrDataAlloc>());
 	}
@@ -217,19 +217,19 @@ namespace bs
 	 * Create a new unique pointer from a previously constructed object.
 	 * Pointer specific data will be allocated using the provided allocator category.
 	 */
-	template<typename Type, typename Alloc = GenAlloc, typename Deleter = decltype(&bs_delete<Type, Alloc>)>
-	UPtr<Type, Alloc, Deleter> bs_unique_ptr(Type* data, Deleter del = &bs_delete<Type, Alloc>)
+	template<typename Type, typename Alloc = GenAlloc, typename Delete = Deleter<Type, Alloc>>
+	UPtr<Type, Alloc, Delete> bs_unique_ptr(Type* data, Delete del = Delete())
 	{
-		return std::unique_ptr<Type, Deleter>(data, std::move(del));
+		return std::unique_ptr<Type, Delete>(data, std::move(del));
 	}
 
 	/** Create a new unique pointer using a custom allocator category. */
-	template<typename Type, typename Alloc = GenAlloc, typename Deleter = decltype(&bs_delete<Type, Alloc>), typename... Args>
-	UPtr<Type, Alloc, Deleter> bs_unique_ptr_new(Args &&... args)
+	template<typename Type, typename Alloc = GenAlloc, typename Delete = Deleter<Type, Alloc>, typename... Args>
+	UPtr<Type, Alloc, Delete> bs_unique_ptr_new(Args &&... args)
 	{
 		Type* rawPtr = bs_new<Type, Alloc>(std::forward<Args>(args)...);
 
-		return bs_unique_ptr<Type, Alloc, Deleter>(rawPtr);
+		return bs_unique_ptr<Type, Alloc, Delete>(rawPtr);
 	}
 
 	/**

--- a/Source/Foundation/bsfUtility/Utility/BsDynLibManager.cpp
+++ b/Source/Foundation/bsfUtility/Utility/BsDynLibManager.cpp
@@ -5,27 +5,26 @@
 
 namespace bs
 {
-
-namespace
-{
-	static void dynlib_delete(DynLib* lib)
+	namespace detail
 	{
-		lib->unload();
-		bs_delete(lib);
+		void dynlib_delete(DynLib* lib)
+		{
+			lib->unload();
+			bs_delete(lib);
+		}
 	}
-} // namespace ()
 
-	static bool operator<(const UPtr<DynLib>& lhs, const String& rhs)
+	static bool operator<(const DynLibManager::LibraryUPtr& lhs, const String& rhs)
 	{
 		return lhs->getName() < rhs;
 	}
 
-	static bool operator<(const String& lhs, const UPtr<DynLib>& rhs)
+	static bool operator<(const String& lhs, const DynLibManager::LibraryUPtr& rhs)
 	{
 		return lhs < rhs->getName();
 	}
 
-	static bool operator<(const UPtr<DynLib>& lhs, const UPtr<DynLib>& rhs)
+	static bool operator<(const DynLibManager::LibraryUPtr& lhs, const DynLibManager::LibraryUPtr& rhs)
 	{
 		return lhs->getName() < rhs->getName();
 	}
@@ -53,7 +52,7 @@ namespace
 		else
 		{
 			DynLib* newLib = bs_new<DynLib>(std::move(filename));
-			mLoadedLibraries.emplace_hint(iterFind, newLib, &dynlib_delete);
+			mLoadedLibraries.emplace_hint(iterFind, newLib, &detail::dynlib_delete);
 			return newLib;
 		}
 	}
@@ -69,7 +68,7 @@ namespace
 		{
 			// Somehow a DynLib not owned by the manager...?
 			// Well, we should clean it up anyway...
-			dynlib_delete(lib);
+			detail::dynlib_delete(lib);
 		}
 	}
 

--- a/Source/Foundation/bsfUtility/Utility/BsDynLibManager.h
+++ b/Source/Foundation/bsfUtility/Utility/BsDynLibManager.h
@@ -7,6 +7,17 @@
 
 namespace bs
 {
+	/** @addtogroup Implementation
+	 *  @{
+	 */
+
+	namespace detail
+	{
+		void dynlib_delete(DynLib* lib);
+	}
+
+	/** @} */
+
 	/** @addtogroup General
 	 *  @{
 	 */
@@ -20,6 +31,8 @@ namespace bs
 	class BS_UTILITY_EXPORT DynLibManager : public Module<DynLibManager>
 	{
 	public:
+		using LibraryUPtr = UPtr<DynLib, GenAlloc, decltype(&detail::dynlib_delete)>;
+
 		/**
 		 * Loads the given file as a dynamic library.
 		 *
@@ -31,7 +44,7 @@ namespace bs
 		void unload(DynLib* lib);
 
 	protected:
-		Set<UPtr<DynLib>, std::less<>> mLoadedLibraries;
+		Set<LibraryUPtr, std::less<>> mLoadedLibraries;
 	};
 
 	/** Easy way of accessing DynLibManager. */

--- a/Source/Plugins/bsfFreeImgImporter/BsFreeImgImporter.cpp
+++ b/Source/Plugins/bsfFreeImgImporter/BsFreeImgImporter.cpp
@@ -219,7 +219,7 @@ namespace bs
 
 	SPtr<PixelData> FreeImgImporter::importRawImage(const Path& filePath)
 	{
-		UPtr<MemoryDataStream> memStream(nullptr, nullptr);
+		UPtr<MemoryDataStream> memStream;
 		FREE_IMAGE_FORMAT imageFormat;
 		{
 			Lock lock = FileScheduler::getLock(filePath);

--- a/Source/Plugins/bsfOpenAudio/BsOAImporter.cpp
+++ b/Source/Plugins/bsfOpenAudio/BsOAImporter.cpp
@@ -50,13 +50,13 @@ namespace bs
 			String extension = filePath.getExtension();
 			StringUtil::toLowerCase(extension);
 
-			UPtr<AudioDecoder> reader(nullptr, nullptr);
+			UPtr<AudioDecoder> reader;
 			if (extension == u8".wav")
-				reader = bs_unique_ptr<AudioDecoder>(bs_new<WaveDecoder>());
+				reader = bs_unique_ptr_new<WaveDecoder>();
 			else if (extension == u8".flac")
-				reader = bs_unique_ptr<AudioDecoder>(bs_new<FLACDecoder>());
+				reader = bs_unique_ptr_new<FLACDecoder>();
 			else if (extension == u8".ogg")
-				reader = bs_unique_ptr<AudioDecoder>(bs_new<OggVorbisDecoder>());
+				reader = bs_unique_ptr_new<OggVorbisDecoder>();
 
 			if (reader == nullptr)
 				return nullptr;


### PR DESCRIPTION
This PR adds a callable `Deleter` struct that serves as a proxy for the `bs_delete` function and is passed by default to the `bs::UPtr` and `bs::SPtr` types. It replaces the use of function pointers to `bs_delete` for these types. Since the new deleter is default-constructible it now allows default-constructible smart pointers like
```cpp
UPtr<A> foo;
SPtr<A> foo;
```
A deleter of a base type is also constructible from a deleter of a derived type, which allows smart pointer polymorphism 
```cpp
class A {};
class B : public A {};

UPtr<A> foo = bs_unique_ptr_new<B>();
SPtr<A> bar= bs_unique_ptr_new<B>();
```
With these changes the bs::f smart pointers behave more like the standard smart pointers while still following the custom allocator architecture.