### PR TITLE
Copy files from correct directory

### DIFF
--- a/Source/CMake/HelperMethods.cmake
+++ b/Source/CMake/HelperMethods.cmake
@@ -471,13 +471,13 @@ endfunction()
 
 function(install_dll_on_build target srcDir)
 	if(WIN32)
-		install_binaries_on_build(${target} ${srcDir}/bin bin dll)
+		install_binaries_on_build(${target} ${srcDir} bin dll)
 	endif()
 endfunction()
 
 function(install_dylib_on_build target srcDir)
 	if(APPLE)
-		install_binaries_on_build(${target} ${srcDir}/bin lib dylib)
+		install_binaries_on_build(${target} ${srcDir} lib dylib)
 	endif()
 endfunction()
 


### PR DESCRIPTION
Make it so files are copied from {srcSir}/bin insread of {srcSir}/bin/bin
Tested and working on windows.

I did the same change for mac but I'm not able to test on mac until this weekend.

