### PR TITLE
Feature: RTTI-PlainType for std::list

### DIFF
--- a/Source/Foundation/bsfUtility/Prerequisites/BsFwdDeclUtil.h
+++ b/Source/Foundation/bsfUtility/Prerequisites/BsFwdDeclUtil.h
@@ -190,6 +190,7 @@ namespace bs
 		TID_IReflectable = 69,
 		TID_DataBlob = 70,
 		TID_ColorGradient = 71,
-		TID_SerializationContext = 72
+		TID_SerializationContext = 72,
+		TID_List = 73
 	};
 }

--- a/Source/Foundation/bsfUtility/Prerequisites/BsRTTIPrerequisites.h
+++ b/Source/Foundation/bsfUtility/Prerequisites/BsRTTIPrerequisites.h
@@ -263,6 +263,76 @@ namespace bs
 	};
 
 	/**
+	 * RTTIPlainType for std::list.
+	 *
+	 * @see		RTTIPlainType
+	 */
+	template<class T> struct RTTIPlainType<std::list<T, StdAlloc<T>>>
+	{
+		enum { id = TID_List }; enum { hasDynamicSize = 1 };
+
+		/** @copydoc RTTIPlainType::toMemory */
+		static void toMemory(const std::list<T, StdAlloc<T>>& data, char* memory)
+		{
+			UINT32 size = sizeof(UINT32);
+			char* memoryStart = memory;
+			memory += sizeof(UINT32);
+
+			UINT32 numElements = (UINT32)data.size();
+			memcpy(memory, &numElements, sizeof(UINT32));
+			memory += sizeof(UINT32);
+			size += sizeof(UINT32);
+
+			for(const auto& item : data)
+			{
+				UINT32 elementSize = rttiGetElemSize(item);
+				RTTIPlainType<T>::toMemory(item, memory);
+
+				memory += elementSize;
+				size += elementSize;
+			}
+
+			memcpy(memoryStart, &size, sizeof(UINT32));
+		}
+
+		/** @copydoc RTTIPlainType::toMemory */
+		static UINT32 fromMemory(std::list<T, StdAlloc<T>>& data, char* memory)
+		{
+			UINT32 size = 0;
+			memcpy(&size, memory, sizeof(UINT32));
+			memory += sizeof(UINT32);
+
+			UINT32 numElements;
+			memcpy(&numElements, memory, sizeof(UINT32));
+			memory += sizeof(UINT32);
+
+			for(UINT32 i = 0; i < numElements; i++)
+			{
+				T element;
+				UINT32 elementSize = RTTIPlainType<T>::fromMemory(element, memory);
+				data.push_back(element);
+
+				memory += elementSize;
+			}
+
+			return size;
+		}
+
+		/** @copydoc RTTIPlainType::toMemory */
+		static UINT32 getDynamicSize(const std::list<T, StdAlloc<T>>& data)
+		{
+			UINT64 dataSize = sizeof(UINT32) * 2;
+
+			for(const auto& item : data)
+				dataSize += rttiGetElemSize(item);
+
+			assert(dataSize <= std::numeric_limits<UINT32>::max());
+
+			return (UINT32)dataSize;
+		}
+	};
+
+	/**
 	 * RTTIPlainType for std::set.
 	 *
 	 * @see		RTTIPlainType

--- a/Source/Foundation/bsfUtility/Prerequisites/BsRTTIPrerequisites.h
+++ b/Source/Foundation/bsfUtility/Prerequisites/BsRTTIPrerequisites.h
@@ -224,7 +224,7 @@ namespace bs
 			memcpy(memoryStart, &size, sizeof(UINT32));
 		}
 
-		/** @copydoc RTTIPlainType::toMemory */
+		/** @copydoc RTTIPlainType::fromMemory */
 		static UINT32 fromMemory(std::vector<T, StdAlloc<T>>& data, char* memory)
 		{
 			UINT32 size = 0;
@@ -248,7 +248,7 @@ namespace bs
 			return size;
 		}
 
-		/** @copydoc RTTIPlainType::toMemory */
+		/** @copydoc RTTIPlainType::getDynamicSize */
 		static UINT32 getDynamicSize(const std::vector<T, StdAlloc<T>>& data)
 		{
 			UINT64 dataSize = sizeof(UINT32) * 2;
@@ -295,7 +295,7 @@ namespace bs
 			memcpy(memoryStart, &size, sizeof(UINT32));
 		}
 
-		/** @copydoc RTTIPlainType::toMemory */
+		/** @copydoc RTTIPlainType::fromMemory */
 		static UINT32 fromMemory(std::list<T, StdAlloc<T>>& data, char* memory)
 		{
 			UINT32 size = 0;
@@ -318,7 +318,7 @@ namespace bs
 			return size;
 		}
 
-		/** @copydoc RTTIPlainType::toMemory */
+		/** @copydoc RTTIPlainType::getDynamicSize */
 		static UINT32 getDynamicSize(const std::list<T, StdAlloc<T>>& data)
 		{
 			UINT64 dataSize = sizeof(UINT32) * 2;
@@ -365,7 +365,7 @@ namespace bs
 			memcpy(memoryStart, &size, sizeof(UINT32));
 		}
 
-		/** @copydoc RTTIPlainType::toMemory */
+		/** @copydoc RTTIPlainType::fromMemory */
 		static UINT32 fromMemory(std::set<T, std::less<T>, StdAlloc<T>>& data, char* memory)
 		{
 			UINT32 size = 0;
@@ -388,7 +388,7 @@ namespace bs
 			return size;
 		}
 
-		/** @copydoc RTTIPlainType::toMemory */
+		/** @copydoc RTTIPlainType::getDynamicSize */
 		static UINT32 getDynamicSize(const std::set<T, std::less<T>, StdAlloc<T>>& data)
 		{
 			UINT64 dataSize = sizeof(UINT32) * 2;


### PR DESCRIPTION
Adds a Plain-Type for `std::list` aka `bs::List`, so you can simply use `BS_RTTI_MEMBER_PLAIN` on member variables of those types.