### PR TITLE
Add toString for vector classes

### DIFF
--- a/Source/Foundation/bsfUtility/Math/BsVector2.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector2.h
@@ -342,6 +342,12 @@ namespace bs
 			return Math::isNaN(x) || Math::isNaN(y);
 		}
 
+		/** Convert the Vector into a human readable string */
+		String toString() const 
+		{
+			return StringFormat::format("<{0}, {1}>", x, y);
+		}
+
 		/** Returns the minimum of all the vector components as a new vector. */
 		static Vector2 min(const Vector2& a, const Vector2& b)
 		{

--- a/Source/Foundation/bsfUtility/Math/BsVector2I.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector2I.h
@@ -198,6 +198,7 @@ namespace bs
 			return x * vec.x + y * vec.y;
 		}
 
+		/** Convert the Vector into a human readable string */
 		String toString() const 
 		{
 			return StringFormat::format("<{0}, {1}>", x, y);

--- a/Source/Foundation/bsfUtility/Math/BsVector2I.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector2I.h
@@ -198,6 +198,11 @@ namespace bs
 			return x * vec.x + y * vec.y;
 		}
 
+		String toString() const 
+		{
+			return StringFormat::format("<{0}, {1}>", x, y);
+		}
+
 		static const Vector2I ZERO;
 	};
 

--- a/Source/Foundation/bsfUtility/Math/BsVector3.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector3.h
@@ -406,6 +406,11 @@ namespace bs
 			return Vector3(std::max(a.x, b.x), std::max(a.y, b.y), std::max(a.z, b.z));
 		}
 
+		String toString() const 
+		{
+			return StringFormat::format("<{0}, {1}, {2}>", x, y, z);
+		}
+
 		static const Vector3 ZERO;
 		static const Vector3 ONE;
 		static const Vector3 INF;

--- a/Source/Foundation/bsfUtility/Math/BsVector3.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector3.h
@@ -406,6 +406,7 @@ namespace bs
 			return Vector3(std::max(a.x, b.x), std::max(a.y, b.y), std::max(a.z, b.z));
 		}
 
+		/** Convert the Vector into a human readable string */
 		String toString() const 
 		{
 			return StringFormat::format("<{0}, {1}, {2}>", x, y, z);

--- a/Source/Foundation/bsfUtility/Math/BsVector3I.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector3I.h
@@ -59,6 +59,7 @@ namespace bs
 			return !operator==(rhs);
 		}
 
+		/** Convert the Vector into a human readable string */
 		String toString() const 
 		{
 			return StringFormat::format("<{0}, {1}, {2}>", x, y, z);

--- a/Source/Foundation/bsfUtility/Math/BsVector3I.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector3I.h
@@ -58,6 +58,11 @@ namespace bs
 		{
 			return !operator==(rhs);
 		}
+
+		String toString() const 
+		{
+			return StringFormat::format("<{0}, {1}, {2}>", x, y, z);
+		}
 	};
 
 	/** @} */

--- a/Source/Foundation/bsfUtility/Math/BsVector4.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector4.h
@@ -263,6 +263,7 @@ namespace bs
 		/** Checks are any of the vector components NaN. */
 		inline bool isNaN() const;
 
+		/** Convert the Vector into a human readable string */
 		String toString() const 
 		{
 			return StringFormat::format("<{0}, {1}, {2}, {3}>", x, y, z, w);

--- a/Source/Foundation/bsfUtility/Math/BsVector4.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector4.h
@@ -263,6 +263,11 @@ namespace bs
 		/** Checks are any of the vector components NaN. */
 		inline bool isNaN() const;
 
+		String toString() const 
+		{
+			return StringFormat::format("<{0}, {1}, {2}, {3}>", x, y, z, w);
+		}
+
 		static const Vector4 ZERO;
 	};
 

--- a/Source/Foundation/bsfUtility/Math/BsVector4I.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector4I.h
@@ -62,6 +62,7 @@ namespace bs
 			return !operator==(rhs);
 		}
 
+		/** Convert the Vector into a human readable string */
 		String toString() const 
 		{
 			return StringFormat::format("<{0}, {1}, {2}, {3}>", x, y, z, w);

--- a/Source/Foundation/bsfUtility/Math/BsVector4I.h
+++ b/Source/Foundation/bsfUtility/Math/BsVector4I.h
@@ -61,6 +61,11 @@ namespace bs
 		{
 			return !operator==(rhs);
 		}
+
+		String toString() const 
+		{
+			return StringFormat::format("<{0}, {1}, {2}, {3}>", x, y, z, w);
+		}
 	};
 
 	/** @} */


### PR DESCRIPTION
Add a toString method for all VectorXT classes, following the format '<X, Y, ...>'.

If there's any interest/this is accepted at all I can add some for the other math classes.