### PR TITLE
Make CMake install the needed bslinc raw files

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -282,6 +282,12 @@ install(
 	DIRECTORY ../Data
 	DESTINATION ${DATA_DST_DIR}
 	PATTERN "../Data/Raw" EXCLUDE
+	PATTERN "../Data/Shaders/Includes" EXCLUDE
 	PATTERN ".version" EXCLUDE
 	PATTERN ".reqversion" EXCLUDE
+)
+
+install(
+    DIRECTORY ../Data/Raw/Shaders/Includes
+	DESTINATION ${DATA_DST_DIR}/Data/Shaders
 )


### PR DESCRIPTION
As discussed on discord, the raw bslinc assets are needed for compiling shaders, and the asset versions of shader includes are unnecessary (they don't work), this changes the cmake install to include the raw shader includes and exclude the compiled shader includes.