### PR TITLE
Fix BS_LOG and array related RTTI makros not working outside the bs-namespace

### DIFF
--- a/Source/Foundation/bsfCore/Image/BsPixelUtil.cpp
+++ b/Source/Foundation/bsfCore/Image/BsPixelUtil.cpp
@@ -2515,13 +2515,13 @@ namespace bs
 	{
 		if (!isCompressed(options.format))
 		{
-			BS_LOG(Error, PixelUtility, "Compression failed. Destination format is not a valid compressed format.")
+			BS_LOG(Error, PixelUtility, "Compression failed. Destination format is not a valid compressed format.");
 			return;
 		}
 
 		if (src.getDepth() != 1)
 		{
-			BS_LOG(Error, PixelUtility, "Compression failed. 3D texture compression not supported.")
+			BS_LOG(Error, PixelUtility, "Compression failed. 3D texture compression not supported.");
 			return;
 		}
 
@@ -2579,13 +2579,13 @@ namespace bs
 
 		if (src.getDepth() != 1)
 		{
-			BS_LOG(Error, PixelUtility, "Mipmap generation failed. 3D texture formats not supported.")
+			BS_LOG(Error, PixelUtility, "Mipmap generation failed. 3D texture formats not supported.");
 			return outputMipBuffers;
 		}
 
 		if (isCompressed(src.getFormat()))
 		{
-			BS_LOG(Error, PixelUtility, "Mipmap generation failed. Source data cannot be compressed.")
+			BS_LOG(Error, PixelUtility, "Mipmap generation failed. Source data cannot be compressed.");
 			return outputMipBuffers;
 		}
 

--- a/Source/Foundation/bsfCore/Physics/BsRigidbody.cpp
+++ b/Source/Foundation/bsfCore/Physics/BsRigidbody.cpp
@@ -25,7 +25,7 @@ namespace bs
 
 		if(!scene)
 		{
-			BS_LOG(Error, Physics, "Trying to create a Rigidbody with an uninstantiated scene object.")
+			BS_LOG(Error, Physics, "Trying to create a Rigidbody with an uninstantiated scene object.");
 			return nullptr;
 		}
 

--- a/Source/Foundation/bsfCore/Profiling/BsProfilerGPU.cpp
+++ b/Source/Foundation/bsfCore/Profiling/BsProfilerGPU.cpp
@@ -117,7 +117,7 @@ namespace bs
 
 		if (mReportCount == 0)
 		{
-			BS_LOG(Error, Profiler, "No reports are available.")
+			BS_LOG(Error, Profiler, "No reports are available.");
 			return GPUProfilerReport();
 		}
 

--- a/Source/Foundation/bsfCore/Resources/BsResources.cpp
+++ b/Source/Foundation/bsfCore/Resources/BsResources.cpp
@@ -488,7 +488,7 @@ namespace bs
 		}
 
 		if (loadedData == nullptr)
-			BS_LOG(Error, Resources, "Unable to load resource at path \"{0}\"", filePath)
+			BS_LOG(Error, Resources, "Unable to load resource at path \"{0}\"", filePath);
 		else
 		{
 			if (!loadedData->isDerivedFrom(Resource::getRTTIStatic()))

--- a/Source/Foundation/bsfEngine/GUI/BsGUIInputTool.cpp
+++ b/Source/Foundation/bsfEngine/GUI/BsGUIInputTool.cpp
@@ -115,7 +115,7 @@ namespace bs
 			return charRect;
 		}
 
-		BS_LOG(Error, GUI, "Invalid character index: {0}", charIdx)
+		BS_LOG(Error, GUI, "Invalid character index: {0}", charIdx);
 		return Rect2I();
 	}
 

--- a/Source/Foundation/bsfEngine/Resources/BsBuiltinResourcesHelper.cpp
+++ b/Source/Foundation/bsfEngine/Resources/BsBuiltinResourcesHelper.cpp
@@ -628,7 +628,7 @@ namespace bs
 #if BS_DEBUG_MODE
 			BS_EXCEPT(InvalidStateException, "Error occured while compiling a shader. Check earlier log messages for exact error.");
 #else
-			BS_LOG(Error, Importer, "Error occured while compiling a shader. Check earlier log messages for exact error.")
+			BS_LOG(Error, Importer, "Error occured while compiling a shader. Check earlier log messages for exact error.");
 #endif
 			return false;
 		}
@@ -673,7 +673,7 @@ namespace bs
 #if BS_DEBUG_MODE
 						BS_EXCEPT(InvalidStateException, errMsg);
 #else
-						BS_LOG(Error, Importer, errMsg)
+						BS_LOG(Error, Importer, errMsg);
 #endif
 						return false;
 					}

--- a/Source/Foundation/bsfUtility/Debug/BsDebug.h
+++ b/Source/Foundation/bsfUtility/Debug/BsDebug.h
@@ -119,17 +119,23 @@ namespace bs
 /** Get the ID of the log category based on its name. */
 #define BS_LOG_GET_CATEGORY_ID(category) LogCategory##category::_id
 
-#define BS_LOG(verbosity, category, message, ...)	{																		\
-	if((INT32)LogVerbosity::verbosity <= (INT32)BS_LOG_VERBOSITY) {															\
-		bs::gDebug().log(StringUtil::format(message, ##__VA_ARGS__) + String("\n\t\t in ") + __PRETTY_FUNCTION__ +			\
-			" [" + __FILE__ + ":" + toString(__LINE__) + "]\n", LogVerbosity::verbosity, LogCategory##category::_id);		\
-	}}
+#define BS_LOG(verbosity, category, message, ...)                                                \
+  do                                                                                             \
+  {                                                                                              \
+    using namespace ::bs;                                                                        \
+    if ((INT32)LogVerbosity::verbosity <= (INT32)BS_LOG_VERBOSITY)                               \
+    {                                                                                            \
+      gDebug().log(StringUtil::format(message, ##__VA_ARGS__) + String("\n\t\t in ") +           \
+                       __PRETTY_FUNCTION__ + " [" + __FILE__ + ":" + toString(__LINE__) + "]\n", \
+                   LogVerbosity::verbosity, LogCategory##category::_id);                         \
+    }                                                                                            \
+  } while (0)
 
-BS_LOG_CATEGORY(Uncategorized, 0)
-BS_LOG_CATEGORY(FileSystem, 1)
-BS_LOG_CATEGORY(RTTI, 2)
-BS_LOG_CATEGORY(Generic, 3)
-BS_LOG_CATEGORY(Platform, 4)
+  BS_LOG_CATEGORY(Uncategorized, 0)
+  BS_LOG_CATEGORY(FileSystem, 1)
+  BS_LOG_CATEGORY(RTTI, 2)
+  BS_LOG_CATEGORY(Generic, 3)
+  BS_LOG_CATEGORY(Platform, 4)
 
-	/** @} */
+  /** @} */
 }

--- a/Source/Foundation/bsfUtility/Reflection/BsRTTIType.h
+++ b/Source/Foundation/bsfUtility/Reflection/BsRTTIType.h
@@ -71,10 +71,10 @@ namespace bs
 #define BS_RTTI_MEMBER_PLAIN_ARRAY_FULL(name, field, id, info)									\
 	META_Entry_##name;																			\
 																								\
-	std::common_type<decltype(OwnerType::field)>::type::value_type& get##name(OwnerType* obj, UINT32 idx) { return obj->field[idx]; }				\
-	void set##name(OwnerType* obj, UINT32 idx, std::common_type<decltype(OwnerType::field)>::type::value_type& val) { obj->field[idx] = val; }		\
-	UINT32 getSize##name(OwnerType* obj) { return (UINT32)obj->field.size(); }																		\
-	void setSize##name(OwnerType* obj, UINT32 val) { obj->field.resize(val); }																		\
+	std::common_type<decltype(OwnerType::field)>::type::value_type& get##name(OwnerType* obj, ::bs::UINT32 idx) { return obj->field[idx]; }				\
+	void set##name(OwnerType* obj, ::bs::UINT32 idx, std::common_type<decltype(OwnerType::field)>::type::value_type& val) { obj->field[idx] = val; }		\
+	::bs::UINT32 getSize##name(OwnerType* obj) { return (::bs::UINT32)obj->field.size(); }																		\
+	void setSize##name(OwnerType* obj, ::bs::UINT32 val) { obj->field.resize(val); }																		\
 																								\
 	struct META_NextEntry_##name{};																\
 	void META_InitPrevEntry(META_NextEntry_##name typeId)										\
@@ -139,15 +139,15 @@ namespace bs
 #define BS_RTTI_MEMBER_REFL_ARRAY_FULL(name, field, id, info)									\
 	META_Entry_##name;																			\
 																								\
-	std::common_type<decltype(OwnerType::field)>::type::value_type& get##name(OwnerType* obj, UINT32 idx) { return obj->field[idx]; }				\
-	void set##name(OwnerType* obj, UINT32 idx, std::common_type<decltype(OwnerType::field)>::type::value_type& val) { obj->field[idx] = val; }		\
-	UINT32 getSize##name(OwnerType* obj) { return (UINT32)obj->field.size(); }					\
-	void setSize##name(OwnerType* obj, UINT32 val) { obj->field.resize(val); }					\
+	std::common_type<decltype(OwnerType::field)>::type::value_type& get##name(OwnerType* obj, ::bs::UINT32 idx) { return obj->field[idx]; }				\
+	void set##name(OwnerType* obj, ::bs::UINT32 idx, std::common_type<decltype(OwnerType::field)>::type::value_type& val) { obj->field[idx] = val; }		\
+	::bs::UINT32 getSize##name(OwnerType* obj) { return (::bs::UINT32)obj->field.size(); }		\
+	void setSize##name(OwnerType* obj, ::bs::UINT32 val) { obj->field.resize(val); }			\
 																								\
 	struct META_NextEntry_##name{};																\
 	void META_InitPrevEntry(META_NextEntry_##name typeId)										\
 	{																							\
-		addReflectableArrayField(#name, id, &MyType::get##name, &MyType::getSize##name, &MyType::set##name, &MyType::setSize##name, info);			\
+		addReflectableArrayField(#name, id, &MyType::get##name, &MyType::getSize##name, &MyType::set##name, &MyType::setSize##name, info);	\
 		META_InitPrevEntry(META_Entry_##name());												\
 	}																							\
 																								\
@@ -208,10 +208,10 @@ namespace bs
 #define BS_RTTI_MEMBER_REFLPTR_ARRAY_FULL(name, field, id, info)								\
 	META_Entry_##name;																			\
 																								\
-	std::common_type<decltype(OwnerType::field)>::type::value_type get##name(OwnerType* obj, UINT32 idx) { return obj->field[idx]; }				\
-	void set##name(OwnerType* obj, UINT32 idx, std::common_type<decltype(OwnerType::field)>::type::value_type val) { obj->field[idx] = val; }		\
-	UINT32 getSize##name(OwnerType* obj) { return (UINT32)obj->field.size(); }					\
-	void setSize##name(OwnerType* obj, UINT32 val) { obj->field.resize(val); }					\
+	std::common_type<decltype(OwnerType::field)>::type::value_type get##name(OwnerType* obj, ::bs::UINT32 idx) { return obj->field[idx]; }				\
+	void set##name(OwnerType* obj, ::bs::UINT32 idx, std::common_type<decltype(OwnerType::field)>::type::value_type val) { obj->field[idx] = val; }		\
+	::bs::UINT32 getSize##name(OwnerType* obj) { return (::bs::UINT32)obj->field.size(); }					\
+	void setSize##name(OwnerType* obj, ::bs::UINT32 val) { obj->field.resize(val); }					\
 																								\
 	struct META_NextEntry_##name{};																\
 	void META_InitPrevEntry(META_NextEntry_##name typeId)										\

--- a/Source/Plugins/bsfD3D11RenderAPI/BsD3D11HardwareBuffer.cpp
+++ b/Source/Plugins/bsfD3D11RenderAPI/BsD3D11HardwareBuffer.cpp
@@ -26,7 +26,7 @@ namespace bs { namespace ct
 
 			if(streamOut)
 			{
-				BS_LOG(Warning, RenderBackend, "useSystemMem and streamOut cannot be used together.")
+				BS_LOG(Warning, RenderBackend, "useSystemMem and streamOut cannot be used together.");
 				streamOut = false;
 			}
 		}

--- a/Source/Plugins/bsfFBXImporter/BsFBXImporter.cpp
+++ b/Source/Plugins/bsfFBXImporter/BsFBXImporter.cpp
@@ -2183,7 +2183,7 @@ namespace bs
 
 		// Resample keys
 		if (!importOptions.animResample && forceResample)
-			BS_LOG(Verbose, FBXImporter, "Animation has different keyframes for different curve components, forcing resampling.")
+			BS_LOG(Verbose, FBXImporter, "Animation has different keyframes for different curve components, forcing resampling.");
 
 		// Make sure to resample along the length of the entire clip
 		curveStart = std::min(curveStart, clipStart);

--- a/Source/Plugins/bsfFreeImgImporter/BsFreeImgImporter.cpp
+++ b/Source/Plugins/bsfFreeImgImporter/BsFreeImgImporter.cpp
@@ -26,9 +26,9 @@ namespace bs
 		// Callback method as required by FreeImage to report problems
 		const char* typeName = FreeImage_GetFormatFromFIF(fif);
 		if (typeName)
-			BS_LOG(Error, FreeImageImporter, "FreeImage error: '{0}' when loading format {1}", message, typeName)
+			BS_LOG(Error, FreeImageImporter, "FreeImage error: '{0}' when loading format {1}", message, typeName);
 		else
-			BS_LOG(Error, FreeImageImporter, "FreeImage error: '{0}'", message)
+			BS_LOG(Error, FreeImageImporter, "FreeImage error: '{0}'", message);
 	}
 
 	FreeImgImporter::FreeImgImporter()


### PR DESCRIPTION
While integrating the new `BS_LOG`-makro into our codebase, I noticed it was directly accessing types from within the `bs` namespace which doesn't work when used from outside the `bs`-namespace. That was also a problem with the array related RTTI-macros, but we worked around the issue before.

This PR fixes both of those cases by explicitly using the types from the `bs`-namespace. The `BS_LOG`-makro was also wrapped in `do { ... } while(0)` to make the compiler complain about missing semicolons, of which there were quite a few.