### PR TITLE
Make BS_LOG_VERBOSITY configurable from outside

### DIFF
--- a/Source/Foundation/bsfUtility/Debug/BsDebug.h
+++ b/Source/Foundation/bsfUtility/Debug/BsDebug.h
@@ -103,10 +103,12 @@ namespace bs
 	/** A simpler way of accessing the Debug module. */
 	BS_UTILITY_EXPORT Debug& gDebug();
 
-#if BS_DEBUG_MODE
-	#define BS_LOG_VERBOSITY LogVerbosity::Log
-#else
-	#define BS_LOG_VERBOSITY LogVerbosity::Warning
+#ifndef BS_LOG_VERBOSITY
+	#if BS_DEBUG_MODE
+		#define BS_LOG_VERBOSITY LogVerbosity::Log
+	#else
+		#define BS_LOG_VERBOSITY LogVerbosity::Warning
+	#endif
 #endif
 
 /** 


### PR DESCRIPTION
This PR allows to set `BS_LOG_VERBOSITY` explicitly from outside, like via the build system, which is useful if you'd want to use `BS_LOG` for your own applications logging but don't need the logs internal to bsf.

To enable logging for a target in CMake, one can use:
```cmake
target_compile_definitions(MyApplication PRIVATE -DBS_LOG_VERBOSITY=LogVerbosity::Log)
```

It still defaults to the old behavior if one does not set it.