### PR TITLE
Added CMake options to build with RTTI and exceptions, and skip debug info handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,8 @@ set(SCRIPT_API "None" CACHE STRING "Which scripting API/language to use, if any.
 set_property(CACHE SCRIPT_API PROPERTY STRINGS "None" "C#")
 
 set(SCRIPT_BINDING_GENERATION OFF CACHE BOOL "If true, script binding generation will be supported through a specialized build target. Enable this if you plan on modifying the scripting API. Requires the SBGen tool dependency. Only relevant if you have selected a SCRIPT_API other than \"None\".")
+
+set(PROCESS_DEBUG_INFO ON CACHE BOOL "If true debug info will be processed into separate file in release builds")
+
+set(ENABLE_EXCEPTIONS OFF CACHE BOOL "If true exceptions will be enabled when compiling")
+set(ENABLE_RTTI OFF CACHE BOOL "If true RTTI will be enabled when compiling")

--- a/Source/CMake/HelperMethods.cmake
+++ b/Source/CMake/HelperMethods.cmake
@@ -372,7 +372,7 @@ function(check_and_update_binary_deps DEP_PREFIX DEP_NAME DEP_FOLDER DEP_VERSION
 endfunction()
 
 function(strip_symbols targetName outputFilename)
-	if(UNIX)
+	if(UNIX AND PROCESS_DEBUG_INFO)
 		if(CMAKE_BUILD_TYPE STREQUAL Release)
 			set(fileToStrip $<TARGET_FILE:${targetName}>)
 

--- a/Source/Foundation/CMakeLists.txt
+++ b/Source/Foundation/CMakeLists.txt
@@ -73,16 +73,28 @@ target_compile_definitions(bsf PRIVATE
 	$<$<CONFIG:Release>:BS_CONFIG=BS_CONFIG_RELEASE>)
 
 if(MSVC)
-	target_compile_options(bsf PUBLIC
-		$<$<COMPILE_LANGUAGE:CXX>:/GR->)
+	if(NOT ENABLE_RTTI)
+		target_compile_options(bsf PUBLIC
+			$<$<COMPILE_LANGUAGE:CXX>:/GR->)
+	endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-	target_compile_options(bsf PUBLIC
-		-fno-exceptions
-		$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+	if(NOT ENABLE_EXCEPTIONS)
+		target_compile_options(bsf PUBLIC
+			-fno-exceptions)
+	endif()
+	if(NOT ENABLE_RTTI)
+		target_compile_options(bsf PUBLIC
+			$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+	endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	target_compile_options(bsf PUBLIC
-		-fno-exceptions
-		$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+	if(NOT ENABLE_EXCEPTIONS)
+		target_compile_options(bsf PUBLIC
+			-fno-exceptions)
+	endif()
+	if(NOT ENABLE_RTTI)
+		target_compile_options(bsf PUBLIC
+			$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+	endif()
 else()
 # TODO_OTHER_COMPILERS_GO_HERE
 endif()


### PR DESCRIPTION
I need these options in order to link BSF with my game. And I need the
files to be unstripped for my debug info processing scripts to work
properly.

Default values should have the same behaviour as before.