### PR TITLE
Add color property to renderables

### DIFF
--- a/Data/Raw/Shaders/Default.bsl
+++ b/Data/Raw/Shaders/Default.bsl
@@ -17,7 +17,7 @@ shader Surface
 			out float OutGBufferD : SV_Target4)
 		{
 			SurfaceData surfaceData;
-			surfaceData.albedo = float4(0.05f, 0.05f, 0.05f, 1.0f);
+			surfaceData.albedo = float4(0.05f, 0.05f, 0.05f, 1.0f) * gColor;
 			surfaceData.worldNormal.xyz = input.tangentToWorldZ;
 			surfaceData.roughness = 1.0f;
 			surfaceData.metalness = 0.0f;

--- a/Data/Raw/Shaders/Diffuse.bsl
+++ b/Data/Raw/Shaders/Diffuse.bsl
@@ -51,7 +51,7 @@ shader Surface
 			float3 worldNormal = calcWorldNormal(input, normal);
 		
 			SurfaceData surfaceData;
-			surfaceData.albedo = gAlbedoTex.Sample(gAlbedoSamp, uv);
+			surfaceData.albedo = gAlbedoTex.Sample(gAlbedoSamp, uv) * gColor;
 			surfaceData.worldNormal.xyz = worldNormal;
 			surfaceData.roughness = gRoughnessTex.Sample(gRoughnessSamp, uv).x;
 			surfaceData.metalness = gMetalnessTex.Sample(gMetalnessSamp, uv).x;

--- a/Data/Raw/Shaders/Includes/PerObjectData.bslinc
+++ b/Data/Raw/Shaders/Includes/PerObjectData.bslinc
@@ -9,6 +9,7 @@ mixin PerObjectData
 			float4x4 gMatInvWorld;
 			float4x4 gMatWorldNoScale;
 			float4x4 gMatInvWorldNoScale;
+			float4 gColor;
 			float gWorldDeterminantSign;
 			uint gLayer;
 		}	

--- a/Data/Raw/Shaders/Transparent.bsl
+++ b/Data/Raw/Shaders/Transparent.bsl
@@ -65,7 +65,7 @@ shader Surface
 			float3 worldNormal = calcWorldNormal(input, normal);
 		
 			SurfaceData surfaceData;
-			surfaceData.albedo = gAlbedoTex.Sample(gAlbedoSamp, uv);
+			surfaceData.albedo = gAlbedoTex.Sample(gAlbedoSamp, uv) * gColor;
 			surfaceData.worldNormal.xyz = worldNormal;
 			surfaceData.worldNormal.w = 1.0f;
 			surfaceData.roughness = gRoughnessTex.Sample(gRoughnessSamp, uv).x;

--- a/Documentation/Manuals/docs/00_User_Manuals/13_Custom_Materials/02_surfaceShaders.md
+++ b/Documentation/Manuals/docs/00_User_Manuals/13_Custom_Materials/02_surfaceShaders.md
@@ -44,7 +44,7 @@ struct VStoFS
 It must include the following mixins:
  - **VertexInput** (from `VertexInput.bslinc`) - Contains a set of helper methods useful for transforming vertex inputs into outputs.
  - **PerCameraData** (from `PerCameraData.bslinc`) - Provides a variety of camera parameters, including the view-projection matrix, view direction and origin. Check the contents of `PerCameraData.bslinc` to see all the provided properties.
- - **PerObjectData** (from `PerObjectData.bslinc`) - Provides a variety of per-object paramters, including the world transform, world-view-projection matrix and object layer. Check the contents of `PerObjectData.bslinc` to see all the provided properties.
+ - **PerObjectData** (from `PerObjectData.bslinc`) - Provides a variety of per-object paramters, including the world transform, world-view-projection matrix, object layer and object color. Check the contents of `PerObjectData.bslinc` to see all the provided properties.
 
 ~~~~~~~~~~~~~
 #include "$ENGINE$\PerCameraData.bslinc"
@@ -195,7 +195,7 @@ shader Surface
 			out float OutGBufferD : SV_Target4)
 		{
 			SurfaceData surfaceData;
-			surfaceData.albedo = gAlbedoTex.Sample(gAlbedoSamp, input.uv0);
+			surfaceData.albedo = gAlbedoTex.Sample(gAlbedoSamp, input.uv0) * gColor;
 			surfaceData.worldNormal.xyz = float3(0, 1, 0);
 			surfaceData.roughness = 1.0f;
 			surfaceData.metalness = 0.0f;
@@ -402,7 +402,7 @@ shader Surface
 		{
 			// For simplicity we only read the albedo from the texture, and assume other properties are constant
 			SurfaceData surfaceData;
-			surfaceData.albedo = gAlbedoTex.Sample(gAlbedoSamp, input.uv0);
+			surfaceData.albedo = gAlbedoTex.Sample(gAlbedoSamp, input.uv0) * gColor;
 			surfaceData.worldNormal.xyz = float3(0, 1, 0);
 			surfaceData.roughness = 1.0f;
 			surfaceData.metalness = 0.0f;

--- a/Source/Foundation/bsfCore/Components/BsCRenderable.h
+++ b/Source/Foundation/bsfCore/Components/BsCRenderable.h
@@ -65,6 +65,14 @@ namespace bs
 		BS_SCRIPT_EXPORT(n:Layers,pr:getter)
 		UINT64 getLayer() const { return mInternal->getLayer(); }
 
+		/** @copydoc Renderable::setColor */
+		BS_SCRIPT_EXPORT(n:Color, pr : setter)
+		void setColor(Color color) { mInternal->setColor(color); }
+
+		/** @copydoc Renderable::getColor */
+		BS_SCRIPT_EXPORT(n:Color, pr : getter)
+		Color getColor() const { return mInternal->getColor(); }
+
 		/**	Gets world bounds of the mesh rendered by this object. */
 		BS_SCRIPT_EXPORT(n:Bounds,pr:getter)
 		Bounds getBounds() const;

--- a/Source/Foundation/bsfCore/Private/RTTI/BsRenderableRTTI.h
+++ b/Source/Foundation/bsfCore/Private/RTTI/BsRenderableRTTI.h
@@ -24,6 +24,7 @@ namespace bs
 			BS_RTTI_MEMBER_PLAIN(mLayer, 4)
 			BS_RTTI_MEMBER_REFL_ARRAY(mMaterials, 5)
 			BS_RTTI_MEMBER_PLAIN(mCullDistanceFactor, 6)
+			BS_RTTI_MEMBER_PLAIN(mColor, 7)
 		BS_END_RTTI_MEMBERS
 
 	public:

--- a/Source/Foundation/bsfCore/Renderer/BsRenderable.h
+++ b/Source/Foundation/bsfCore/Renderer/BsRenderable.h
@@ -9,6 +9,7 @@
 #include "Math/BsBounds.h"
 #include "Math/BsAABox.h"
 #include "Scene/BsSceneActor.h"
+#include "Image/BsColor.h"
 
 namespace bs
 {
@@ -26,6 +27,13 @@ namespace bs
 		Morph,
 		SkinnedMorph,
 		Count // Keep at end
+	};
+
+	/**	Signals which portion of a Renderable is dirty. */
+	enum class RenderableDirtyFlag
+	{
+		// First few bits reserved by ActorDirtyFlag
+		Color = 1 << 4
 	};
 
 	/**
@@ -82,6 +90,11 @@ namespace bs
 		void setLayer(UINT64 layer);
 
 		/**
+		 * Determines the multiplicative base color used when shading the renderable.
+		 */
+		void setColor(Color color);
+
+		/**
 		 * Sets bounds that will be used when determining if object is visible. Only relevant if setUseOverrideBounds() is
 		 * set to true.
 		 *
@@ -103,6 +116,9 @@ namespace bs
 
 		/** @copydoc setLayer() */
 		UINT64 getLayer() const { return mLayer; }
+
+		/** @copydoc setColor() */
+		Color getColor() const { return mColor; }
 
 		/**	@copydoc setMesh() */
 		MeshType getMesh() const { return mMesh; }
@@ -133,9 +149,13 @@ namespace bs
 		/** Triggered whenever the renderable's mesh changes. */
 		virtual void onMeshChanged() { }
 
+		/** Check if no other flags than ActorDirtyFlag::Transform or RenderableDirtyFlag::Color are set in the given dirtyFlags. */
+		static bool isOnlyTransformOrColorDirty(UINT32 dirtyFlags);
+
 		MeshType mMesh;
 		Vector<MaterialType> mMaterials;
 		UINT64 mLayer = 1;
+		Color mColor = Color::White;
 		AABox mOverrideBounds;
 		bool mUseOverrideBounds = false;
 		float mCullDistanceFactor = 1.0f;

--- a/Source/Foundation/bsfCore/Renderer/BsSkybox.h
+++ b/Source/Foundation/bsfCore/Renderer/BsSkybox.h
@@ -21,7 +21,7 @@ namespace bs
 	/**	Signals which portion of a Skybox is dirty. */
 	enum class SkyboxDirtyFlag
 	{
-		// First few bits reserved by ActorDiryFlag
+		// First few bits reserved by ActorDirtyFlag
 		Texture = 1 << 4
 	};
 

--- a/Source/Plugins/bsfRenderBeast/BsRendererDecal.cpp
+++ b/Source/Plugins/bsfRenderBeast/BsRendererDecal.cpp
@@ -36,7 +36,7 @@ namespace bs { namespace ct
 		const Matrix4 worldTransform = decal->getMatrix() * scaleAndOffset;
 		const Matrix4 worldNoScaleTransform = decal->getMatrixNoScale() * scaleAndOffset;
 
-		PerObjectBuffer::update(perObjectParamBuffer, worldTransform, worldNoScaleTransform, 0);
+		PerObjectBuffer::update(perObjectParamBuffer, worldTransform, worldNoScaleTransform, 0, Color::White);
 
 		const Transform& tfrm = decal->getTransform();
 

--- a/Source/Plugins/bsfRenderBeast/BsRendererRenderable.cpp
+++ b/Source/Plugins/bsfRenderBeast/BsRendererRenderable.cpp
@@ -11,12 +11,13 @@ namespace bs { namespace ct
 	PerCallParamDef gPerCallParamDef;
 
 	void PerObjectBuffer::update(SPtr<GpuParamBlockBuffer>& buffer, const Matrix4& tfrm, const Matrix4& tfrmNoScale,
-		UINT32 layer)
+		UINT32 layer, Color color)
 	{
 		gPerObjectParamDef.gMatWorld.set(buffer, tfrm);
 		gPerObjectParamDef.gMatInvWorld.set(buffer, tfrm.inverseAffine());
 		gPerObjectParamDef.gMatWorldNoScale.set(buffer, tfrmNoScale);
 		gPerObjectParamDef.gMatInvWorldNoScale.set(buffer, tfrmNoScale.inverseAffine());
+		gPerObjectParamDef.gColor.set(buffer, color);
 		gPerObjectParamDef.gWorldDeterminantSign.set(buffer, tfrm.determinant3x3() >= 0.0f ? 1.0f : -1.0f);
 		gPerObjectParamDef.gLayer.set(buffer, (INT32)layer);
 	}
@@ -40,8 +41,9 @@ namespace bs { namespace ct
 		const Matrix4 worldTransform = renderable->getMatrix();
 		const Matrix4 worldNoScaleTransform = renderable->getMatrixNoScale();
 		const UINT32 layer = Bitwise::mostSignificantBit(renderable->getLayer());
+		const Color color = renderable->getColor();
 
-		PerObjectBuffer::update(perObjectParamBuffer, worldTransform, worldNoScaleTransform, layer);
+		PerObjectBuffer::update(perObjectParamBuffer, worldTransform, worldNoScaleTransform, layer, color);
 	}
 
 	void RendererRenderable::updatePerCallBuffer(const Matrix4& viewProj, bool flush)

--- a/Source/Plugins/bsfRenderBeast/BsRendererRenderable.h
+++ b/Source/Plugins/bsfRenderBeast/BsRendererRenderable.h
@@ -21,6 +21,7 @@ namespace bs { namespace ct
 		BS_PARAM_BLOCK_ENTRY(Matrix4, gMatInvWorld)
 		BS_PARAM_BLOCK_ENTRY(Matrix4, gMatWorldNoScale)
 		BS_PARAM_BLOCK_ENTRY(Matrix4, gMatInvWorldNoScale)
+		BS_PARAM_BLOCK_ENTRY(Color, gColor)
 		BS_PARAM_BLOCK_ENTRY(float, gWorldDeterminantSign)
 		BS_PARAM_BLOCK_ENTRY(INT32, gLayer)
 	BS_PARAM_BLOCK_END
@@ -39,7 +40,7 @@ namespace bs { namespace ct
 	public:
 		/** Updates the provided buffer with the data from the provided matrices. */
 		static void update(SPtr<GpuParamBlockBuffer>& buffer, const Matrix4& tfrm, const Matrix4& tfrmNoScale,
-			UINT32 layer);
+			UINT32 layer, Color color);
 	};
 
 	struct MaterialSamplerOverrides;

--- a/Source/Plugins/bsfRenderBeast/BsRendererScene.cpp
+++ b/Source/Plugins/bsfRenderBeast/BsRendererScene.cpp
@@ -621,14 +621,14 @@ namespace bs {	namespace ct
 		if(tfrmOnly)
 		{
 			SPtr<GpuParamBlockBuffer>& paramBuffer = rendererParticles.perObjectParamBuffer;
-			PerObjectBuffer::update(paramBuffer, rendererParticles.localToWorld, localToWorldNoScale, layer);
+			PerObjectBuffer::update(paramBuffer, rendererParticles.localToWorld, localToWorldNoScale, layer, Color::White);
 
 			return;
 		}
 
 		SPtr<GpuParamBlockBuffer> perObjectParamBuffer = gPerObjectParamDef.createBuffer();
 		SPtr<GpuParamBlockBuffer> particlesParamBuffer = gParticlesParamDef.createBuffer();
-		PerObjectBuffer::update(perObjectParamBuffer, rendererParticles.localToWorld, localToWorldNoScale, layer);
+		PerObjectBuffer::update(perObjectParamBuffer, rendererParticles.localToWorld, localToWorldNoScale, layer, Color::White);
 
 		Vector3 axisForward = settings.orientationPlaneNormal;
 


### PR DESCRIPTION
This PR introduces a `color` property to renderables, more specifically it adds a multiplicative base color which is set on a per-instance basis. A typical use case is having many object instances sharing the same mesh and basically the same material, except for slight color variations. With the classical pipeline you would need to create one material per instance, resulting in one instanciation of the shader per instance (which is slow when having a large amount of objects). 

Although this change arguably serves a niche use case, I find adding this property benefits the framework and integrates really well with the rest of the per object properties available in the shaders.

The PR can be seen as a first basic implementation and currently only covers renderables, although it is probably also applicable to shaded particles and decals. I'm of course open to feedback, if anything needs to be change or extended.