### PR TITLE
Replaced type punning with a memcpy

### DIFF
--- a/Source/Foundation/bsfUtility/Utility/BsBitwise.h
+++ b/Source/Foundation/bsfUtility/Utility/BsBitwise.h
@@ -679,7 +679,9 @@ namespace bs
 				output = ((exponent + 112) << 23) | (mantissa << 18);
 			}
 
-			return *(float*)&output;
+			float result;
+			std::memcpy(&result, &output, sizeof(float));
+			return result;
 		}
 
 		/** Converts a 11-bit float to a 32-bit float according to OpenGL packed_float extension. */
@@ -719,7 +721,9 @@ namespace bs
 				output = ((exponent + 112) << 23) | (mantissa << 17);
 			}
 
-			return *(float*)&output;
+			float result;
+			std::memcpy(&result, &output, sizeof(float));
+			return result;
 		}
 
 		/**


### PR DESCRIPTION
Silences a warning from GCC. AFAIK this is the only correct way to
read the data through a different type "pointer."

fixes #330 