### PR TITLE
Meta: add DCO-1.1 to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,30 @@ Good pull requests - patches, improvements, new features - are a fantastic help.
 **Please ask first** before embarking on any significant pull request (e.g. implementing features, refactoring code), otherwise you risk spending a lot of time working on something that the project's developers might not want to merge into the project.
 
 Please adhere to the coding conventions used throughout a project (indentation, accurate comments, etc.). See the [code style](https://www.bsframework.io/docs/code_style.html) guide and respect the style of surrounding code.
+
+<a id="developers-certificate-of-origin"></a>
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.


### PR DESCRIPTION
The DCO is a legal protection for some licenses (such as MIT) which do not expressly verify contributors' consent.

MIT also does not have a patents clause, which the DCO helps address.

This is not retroactive, but could help protect future contributions.

If anyone has questions I can _try_ to help answer them. This is used for many Linux Foundation projects these days in place of a Contributor License Agreement (CLA), so it has precedent.

_(Hopefully you're not spooked that is my first PR! bsf seems cool.)_
_(Obligatory: This is not legal advice and I am not an attorney.)_